### PR TITLE
mrc-1491: array support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ r_packages:
 addons:
   apt:
     packages:
-      - libv8-dev
+      - libnode-dev
 r_github_packages:
   - mrc-ide/cinterpolate
   - ropensci/jsonvalidate

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ r_packages:
 addons:
   apt:
     packages:
-      - libnode-dev
+      - libv8-dev
 r_github_packages:
   - mrc-ide/cinterpolate
   - ropensci/jsonvalidate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,6 @@ Imports:
   jsonlite,
   odin (>= 0.2.0)
 Suggests:
+  deSolve,
   testthat
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.2
+Version: 0.1.3
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,7 @@ inst/dopri.js: js/dopri.js
 	cp js/node_modules/dopri/LICENCE inst/LICENSE.dopri
 	cp js/dopri.min.js inst
 
+inst/support_sum.js: R/generate_js_support.R
+	./scripts/create_support_sum_js.R
+
 .PHONY: all test document install vignettes build js example

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -47,11 +47,13 @@ odin_js_bundle <- function(filenames, dest = tempfile(),
 
   dopri <- if (include_dopri) package_js("dopri.js") else NULL
   support <- package_js("support.js")
+  support_sum <- package_js("support_sum.js")
   if (!is.null(include)) {
     include <- js_flatten_eqs(lapply(include, readLines))
   }
   code <- c(dopri,
             support,
+            support_sum,
             sprintf("var %s = {};", JS_GENERATORS),
             js_flatten_eqs(lapply(dat, "[[", "code")),
             include)

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -135,8 +135,17 @@ generate_js_core_rhs_eval <- function(eqs, dat, rewrite) {
 generate_js_core_initial_conditions <- function(eqs, dat, rewrite) {
   set_initial <- function(el) {
     data_info <- dat$data$elements[[el$name]]
-    lhs <- js_variable_reference(el, data_info, dat$meta$state, rewrite)
-    sprintf("%s = %s.%s;", lhs, dat$meta$internal, el$initial)
+    if (data_info$rank == 0L) {
+      lhs <- js_variable_reference(el, data_info, dat$meta$state, rewrite)
+      sprintf("%s = %s.%s;", lhs, dat$meta$internal, el$initial)
+    } else {
+      c(sprintf("for (var i = 0; i < %s; ++i) {",
+                rewrite(data_info$dimnames$length)),
+        sprintf("  %s[%s + i] = %s.%s[i];",
+                dat$meta$state, rewrite(el$offset),
+                dat$meta$internal, el$initial),
+        "}")
+    }
   }
 
   internal <- sprintf("var %s = this.%s;",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -171,7 +171,7 @@ generate_js_core_initial_conditions <- function(eqs, dat, rewrite) {
   set_initial <- function(el) {
     data_info <- dat$data$elements[[el$name]]
     if (data_info$rank == 0L) {
-      lhs <- js_variable_reference(el, data_info, dat$meta$state, rewrite)
+      lhs <- sprintf("%s[%s]", dat$meta$state, rewrite(el$offset))
       sprintf("%s = %s.%s;", lhs, dat$meta$internal, el$initial)
     } else {
       c(sprintf("for (var i = 0; i < %s; ++i) {",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -5,6 +5,14 @@ generate_js <- function(ir, options) {
     generate_js_sexp(x, dat$data, dat$meta)
   }
 
+  features <- vlapply(dat$features, identity)
+  supported <- c("has_array")
+  unsupported <- setdiff(names(features)[features], supported)
+  if (length(unsupported) > 0L) {
+    stop("Using unsupported features: ",
+         paste(squote(unsupported, collapse = ", ")))
+  }
+
   eqs <- generate_js_equations(dat, rewrite)
   core <- generate_js_core(eqs, dat, rewrite)
 

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -127,13 +127,13 @@ generate_js_core_metadata <- function(eqs, dat, rewrite) {
         ynames <- c(
           ynames,
           sprintf("for (var i = 1; i <= %s; ++i) {", len),
-          sprintf("  this.metadata.ynames.push(`%s[${i}]`);", el$name),
+          sprintf('  this.metadata.ynames.push("%s[" + i + "]");', el$name),
           sprintf("}"))
       } else {
         rank <- el$rank
         index <- paste0("i", seq_len(rank))
-        pos <- paste(sprintf("${%s}", index), collapse = ",")
-        ynames1 <- sprintf("this.metadata.ynames.push(`%s[%s]`);",
+        pos <- paste(index, collapse = ' + "," + ')
+        ynames1 <- sprintf('this.metadata.ynames.push("%s[" + %s + "]");',
                            el$name, pos)
         for (i in seq_len(rank)) {
           len <- rewrite(el$dimnames$dim[[i]])

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -109,8 +109,6 @@ generate_js_coef <- function(eqs, dat, rewrite) {
 
 
 generate_js_core_metadata <- function(eqs, dat, rewrite) {
-  ## This will need major work for both arrays and output, but I think
-  ## that the solver does not yet cope with output
   stopifnot(!dat$features$has_output)
 
   body <- c("this.metadata = {};",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -6,11 +6,11 @@ generate_js <- function(ir, options) {
   }
 
   features <- vlapply(dat$features, identity)
-  supported <- c("has_array")
+  supported <- c("initial_time_dependent", "has_array", "has_user")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {
     stop("Using unsupported features: ",
-         paste(squote(unsupported, collapse = ", ")))
+         paste(squote(unsupported), collapse = ", "))
   }
 
   eqs <- generate_js_equations(dat, rewrite)

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -126,11 +126,23 @@ generate_js_core_metadata <- function(eqs, dat, rewrite) {
         len <- rewrite(el$dimnames$length)
         ynames <- c(
           ynames,
-          sprintf("for (var i = 0; i < %s; ++i) {", len),
-          sprintf("  this.metadata.ynames.push(`%s[${i + 1}]`);", el$name),
+          sprintf("for (var i = 1; i <= %s; ++i) {", len),
+          sprintf("  this.metadata.ynames.push(`%s[${i}]`);", el$name),
           sprintf("}"))
       } else {
-        stop("WRITEME")
+        rank <- el$rank
+        index <- paste0("i", seq_len(rank))
+        pos <- paste(sprintf("${%s}", index), collapse = ",")
+        ynames1 <- sprintf("this.metadata.ynames.push(`%s[%s]`);",
+                           el$name, pos)
+        for (i in seq_len(rank)) {
+          len <- rewrite(el$dimnames$dim[[i]])
+          loop <- sprintf("for (var %s = 1; %s <= %s; ++%s) {",
+                          index[[i]], index[[i]], len, index[[i]])
+          ynames1 <- c(loop, paste0("  ", ynames1), "}")
+        }
+
+        ynames <- c(ynames, ynames1)
       }
     }
     body <- c(body, ynames)

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -52,7 +52,7 @@ generate_js_equation_user <- function(eq, data_info, dat, rewrite) {
     ret <- c(
       sprintf("var %s = new Array(%d);", len, rank + 1),
       sprintf(
-        'getUserArrayDim(%s, "%s", %s, %s, %d, %s, %s, %s);',
+        'getUserArrayDim(%s, "%s", %s, %s, %s, %s, %s, %s);',
         user, eq$lhs, internal, len, default,
         min, max, is_integer),
       sprintf("%s = %s[%d];", rewrite(len), len, 0),

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -102,7 +102,12 @@ generate_js_equation_array_lhs <- function(eq, data_info, dat, rewrite) {
   if (eq$type == "expression_array") {
     index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
   } else {
-    index <- lapply(eq$rhs$index, "[[", "index")
+    ## This is here to support delays, which are not yet supported.
+    ## This *shoul* work but leaving in an assertion so that I
+    ## remember to double check it and remove the "no coverage"
+    ## marker.
+    stop("check for delays") # nocov
+    index <- lapply(eq$rhs$index, "[[", "index") # nocov
   }
   location <- data_info$location
 

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -133,9 +133,6 @@ generate_js_equation_array_lhs <- function(eq, data_info, dat, rewrite) {
 }
 
 
-## TODO: we should really use size_t for the index variables here, but
-## because the sizes are not yet stored as size_t that causes a lot of
-## compiler warning noise.
 generate_js_equation_array_rhs <- function(value, index, lhs, rewrite) {
   ret <- sprintf("%s = %s;", lhs, rewrite(value))
   seen_range <- FALSE

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -26,6 +26,8 @@ generate_js_sexp <- function(x, data, meta) {
     } else if (fn == "dim") {
       dim <- data$elements[[args[[1L]]]]$dimnames$dim[[args[[2]]]]
       ret <- generate_js_sexp(dim, data, meta)
+    } else if (fn == "sum" || fn == "odin_sum") {
+      ret <- generate_js_sexp_sum(args, data, meta)
     } else {
       if (any(FUNCTIONS_MATH == fn)) {
         fn <- sprintf("Math.%s", fn)
@@ -45,6 +47,29 @@ generate_js_sexp <- function(x, data, meta) {
     }
   } else if (is.numeric(x)) {
     deparse(x, control = "digits17")
+  }
+}
+
+
+## This just works the same way that the C version does, even if there
+## might be a better way in js.
+generate_js_sexp_sum <- function(args, data, meta) {
+  target <- generate_js_sexp(args[[1]], data, meta)
+  data_info <- data$elements[[args[[1]]]]
+
+  if (length(args) == 1L) {
+    len <- generate_js_sexp(data_info$dimnames$length, data, meta)
+    sprintf("odinSum1(%s, 0, %s)", target, len)
+  } else {
+    i <- seq(2, length(args), by = 2)
+
+    all_args <- c(args, as.list(data_info$dimnames$mult[-1]))
+    values <- character(length(all_args))
+    values[i] <- vcapply(all_args[i], js_minus_1, FALSE, data, meta)
+    values[-i] <- vcapply(all_args[-i], generate_js_sexp, data, meta)
+    arg_str <- paste(values, collapse = ", ")
+
+    sprintf("odinSum%d(%s)", length(i), arg_str)
   }
 }
 

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -7,6 +7,9 @@ generate_js_sexp <- function(x, data, meta) {
 
     if (fn == "(") {
       ret <- sprintf("(%s)", values[[1]])
+    } else if (fn == "[") {
+      pos <- js_array_access(args[[1L]], args[-1], data, meta)
+      ret <- sprintf("%s[%s]", values[[1L]], pos)
     } else if (n == 2L && fn %in% odin:::FUNCTIONS_INFIX) {
       ret <- sprintf("%s %s %s", values[[1]], fn, values[[2]])
     } else if (fn == "if") {

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -20,6 +20,12 @@ generate_js_sexp <- function(x, data, meta) {
       ## parens for now.
       ret <- sprintf("(%s ? %s : %s)",
                      values[[1L]], values[[2L]], values[[3L]])
+    } else if (fn == "length") {
+      ret <- generate_js_sexp(data$elements[[args[[1L]]]]$dimnames$length,
+                              data, meta)
+    } else if (fn == "dim") {
+      dim <- data$elements[[args[[1L]]]]$dimnames$dim[[args[[2]]]]
+      ret <- generate_js_sexp(dim, data, meta)
     } else {
       if (any(FUNCTIONS_MATH == fn)) {
         fn <- sprintf("Math.%s", fn)

--- a/R/generate_js_support.R
+++ b/R/generate_js_support.R
@@ -1,0 +1,37 @@
+generate_js_support_sum <- function(rank) {
+  i <- seq_len(rank)
+
+  index <- c("i", "j", "k", "l", "i5", "i6", "i7", "i8")[i]
+  mult <- vcapply(seq_len(rank), function(x)
+    sprintf("dim%s", paste(seq_len(x - 1), collapse = "")))
+  counter <- vcapply(index, strrep, times = 2, USE.NAMES = FALSE)
+
+  limits <- rbind(sprintf("%sFrom", index),
+                  sprintf("%sTo", index))
+  args <- c("x", limits, mult[-1])
+
+  loop_open <- sprintf("for (var %s = %s; %s < %s; ++%s) {",
+                       index, limits[1, i], index, limits[2, i], index)
+
+  for (j in i) {
+    if (j == 1L) {
+      loop_body <- sprintf("tot += x[%s + %s];",
+                           index[[j]], counter[[j + 1]])
+    } else {
+      if (j == rank) {
+        set_counter <- sprintf("var %s = %s * %s;",
+                               counter[[j]], index[[j]], mult[[j]])
+      } else {
+        set_counter <- sprintf("var %s = %s * %s + %s;",
+                               counter[[j]], index[[j]],
+                               mult[[j]], counter[[j + 1]])
+      }
+      loop_body <- c(set_counter, loop)
+    }
+    loop <- c(loop_open[[j]], paste0("  ", loop_body), "}")
+  }
+
+  body <- c("var tot = 0.0;", loop, "return tot;")
+
+  js_function(args, body, sprintf("odinSum%d", rank))
+}

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -31,7 +31,12 @@ js_unpack_variable <- function(name, dat, state, rewrite) {
 
 
 js_variable_reference <- function(x, data_info, state, rewrite) {
-  sprintf("%s[%s]", state, rewrite(x$offset))
+  if (data_info$rank == 0L) {
+    sprintf("%s[%s]", state, rewrite(x$offset))
+  } else {
+    stop("needs work?")
+    sprintf("%s[%s + %s]", state, rewrite(x$offset))
+  }
 }
 
 

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -33,3 +33,30 @@ js_unpack_variable <- function(name, dat, state, rewrite) {
 js_variable_reference <- function(x, data_info, state, rewrite) {
   sprintf("%s[%s]", state, rewrite(x$offset))
 }
+
+
+js_array_access <- function(target, index, data, meta) {
+  mult <- data$elements[[target]]$dimnames$mult
+
+  f <- function(i) {
+    index_i <- js_minus_1(index[[i]], i > 1, data, meta)
+    if (i == 1) {
+      index_i
+    } else {
+      mult_i <- generate_js_sexp(mult[[i]], data, meta)
+      sprintf("%s * %s", mult_i, index_i)
+    }
+  }
+
+  paste(vcapply(rev(seq_along(index)), f), collapse = " + ")
+}
+
+
+js_minus_1 <- function(x, protect, data, meta) {
+  if (is.numeric(x)) {
+    generate_js_sexp(x - 1L, data, meta)
+  } else {
+    x_expr <- generate_js_sexp(x, data, meta)
+    sprintf(if (protect) "(%s - 1)" else "%s - 1", x_expr)
+  }
+}

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -18,8 +18,13 @@ js_function <- function(args, body, name = NULL) {
 
 js_extract_variable <- function(x, data_elements, state, rewrite) {
   d <- data_elements[[x$name]]
-  stopifnot(d$rank == 0L)
-  sprintf("%s[%s]", state, rewrite(x$offset))
+  if (d$rank == 0L) {
+    sprintf("%s[%s]", state, rewrite(x$offset))
+  } else {
+    offset <- rewrite(x$offset)
+    len <- rewrite(d$dimnames$length)
+    sprintf("%s.slice(%s, %s + %s)", state, offset, offset, len)
+  }
 }
 
 

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -35,16 +35,6 @@ js_unpack_variable <- function(name, dat, state, rewrite) {
 }
 
 
-js_variable_reference <- function(x, data_info, state, rewrite) {
-  if (data_info$rank == 0L) {
-    sprintf("%s[%s]", state, rewrite(x$offset))
-  } else {
-    stop("needs work?")
-    sprintf("%s[%s + %s]", state, rewrite(x$offset))
-  }
-}
-
-
 js_array_access <- function(target, index, data, meta) {
   mult <- data$elements[[target]]$dimnames$mult
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,11 @@ vcapply <- function(X, FUN, ...) {
 }
 
 
+vlapply <- function(X, FUN, ...) {
+  vapply(X, FUN, logical(1), ...)
+}
+
+
 `%||%` <- function(x, y) {
   if (is.null(x)) y else x
 }

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -16,6 +16,23 @@ odin_js_wrapper <- function(ir, options) {
 }
 
 
+to_json_user <- function(user) {
+  f <- function(x) {
+    if (is.array(x)) {
+      x <- list(data = c(x), dim = I(dim(x)))
+    } else if (length(x) > 1L || inherits(x, "AsIs")) {
+      x <- list(data = x, dim = I(length(x)))
+    }
+    x
+  }
+  if (length(user) > 0) {
+    stopifnot(!is.null(names(user)))
+  }
+  user <- lapply(user, f)
+  to_json(user, auto_unbox = TRUE)
+}
+
+
 ##' @importFrom R6 R6Class
 R6_odin_js_wrapper <- R6::R6Class(
   "odin_model",
@@ -32,7 +49,7 @@ R6_odin_js_wrapper <- R6::R6Class(
     initialize = function(context, generator, user) {
       private$context <- context
       private$name <- sprintf("%s.%s", JS_INSTANCES, basename(tempfile("i")))
-      user_js <- to_json(user, auto_unbox = TRUE)
+      user_js <- to_json_user(user)
       init <- sprintf("%s = new %s.%s(%s);",
                       private$name, JS_GENERATORS, generator, user_js)
       private$context$eval(init)
@@ -44,7 +61,7 @@ R6_odin_js_wrapper <- R6::R6Class(
     },
 
     set_user = function(user) {
-      user_js <- to_json(user, auto_unbox = TRUE)
+      user_js <- to_json_user(user)
       private$context$call(sprintf("%s.setUser", private$name), user_js)
     },
 

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -67,7 +67,7 @@ R6_odin_js_wrapper <- R6::R6Class(
         y_js <- to_json(y, auto_unbox = FALSE)
       }
       res <- private$context$call(sprintf("%s.run", private$name), t_js, y_js)
-      ## colnames(res$y) <- res$names
+      colnames(res$y) <- res$names
       res$y
     }
   ))

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -97,6 +97,7 @@ js_context <- function() {
   ct <- V8::v8()
   ct$source(system.file("dopri.js", package = "odin.js", mustWork = TRUE))
   ct$source(system.file("support.js", package = "odin.js", mustWork = TRUE))
+  ct$source(system.file("support_sum.js", package = "odin.js", mustWork = TRUE))
   ct$eval(sprintf("var %s = {};", JS_GENERATORS))
   ct$eval(sprintf("var %s = {};", JS_INSTANCES))
   ct

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -59,7 +59,7 @@ R6_odin_js_wrapper <- R6::R6Class(
       private$context$get(sprintf("%s.internal", private$name))
     },
 
-    run = function(t, y = NULL, ...) {
+    run = function(t, y = NULL, ..., use_names = TRUE) {
       t_js <- to_json(t, auto_unbox = FALSE)
       if (is.null(y)) {
         y_js <- V8::JS("null")
@@ -67,7 +67,9 @@ R6_odin_js_wrapper <- R6::R6Class(
         y_js <- to_json(y, auto_unbox = FALSE)
       }
       res <- private$context$call(sprintf("%s.run", private$name), t_js, y_js)
-      colnames(res$y) <- res$names
+      if (use_names) {
+        colnames(res$y) <- res$names
+      }
       res$y
     }
   ))

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -67,7 +67,7 @@ R6_odin_js_wrapper <- R6::R6Class(
         y_js <- to_json(y, auto_unbox = FALSE)
       }
       res <- private$context$call(sprintf("%s.run", private$name), t_js, y_js)
-      colnames(res$y) <- res$names
+      ## colnames(res$y) <- res$names
       res$y
     }
   ))

--- a/inst/support.js
+++ b/inst/support.js
@@ -51,7 +51,7 @@ function getUser(user, name, internal, size, defaultValue,
         if (max !== null && value > min) {
             throw Error("Expected '" + name + "' to be at most " + max);
         }
-        if (isInteger && !Number.isInteger(value)) {
+        if (isInteger && !numberIsInteger(value)) {
             throw Error("Expected '" + name + "' to be integer-like");
         }
 
@@ -172,7 +172,7 @@ function getUserArrayCheckContents(data, min, max, isInteger, name) {
         if (max !== null && data[i] > min) {
             throw Error("Expected '" + name + "' to be at most " + max);
         }
-        if (isInteger && !Number.isInteger(data[i])) {
+        if (isInteger && !numberIsInteger(data[i])) {
             throw Error("Expected a integer value for '" + name + "'");
         }
     }
@@ -182,6 +182,12 @@ function getUserArrayCheckContents(data, min, max, isInteger, name) {
 function isMissing(x) {
     return x === undefined || x === null ||
         (typeof x === "number" && isNaN(x));
+}
+
+
+// Travis has ancient v8 version that lacks Number.isNumber
+function numberIsInteger(x) {
+    return Math.abs(x - Math.round(x)) < Math.sqrt(Number.EPSILON)
 }
 
 

--- a/inst/support.js
+++ b/inst/support.js
@@ -51,6 +51,10 @@ function getUser(user, name, internal, size, defaultValue,
         if (max !== null && value > min) {
             throw Error("Expected '" + name + "' to be at most " + max);
         }
+        if (isInteger && !Number.isInteger(value)) {
+            throw Error("Expected '" + name + "' to be integer-like");
+        }
+
         internal[name] = value;
     }
 }
@@ -167,6 +171,9 @@ function getUserArrayCheckContents(data, min, max, isInteger, name) {
         }
         if (max !== null && data[i] > min) {
             throw Error("Expected '" + name + "' to be at most " + max);
+        }
+        if (isInteger && !Number.isInteger(data[i])) {
+            throw Error("Expected a integer value for '" + name + "'");
         }
     }
 }

--- a/inst/support.js
+++ b/inst/support.js
@@ -55,6 +55,70 @@ function getUser(user, name, internal, size, defaultValue,
     }
 }
 
+
+function getUserArray(user, name, internal, size, defaultValue,
+                      min, max, isInteger) {
+    var value = user[name];
+
+    if (isMissing(value)) {
+        if (isMissing(internal[name])) {
+            if (defaultValue === null) {
+                throw Error("Expected a value for '" + name + "'");
+            } else {
+                // not totally clear how to do this as we need to get
+                // the previous dimensions too!
+                throw Error("This needs implementing....");
+                internal[name] = defaultValue;
+            }
+        }
+        return;
+    }
+
+    var rank = size.length - 1;
+    if (!(typeof value === "object" && "data" in value && "dim" in value)) {
+        throw Error("Expected an odin.js array object for '" + name + "'");
+    }
+    if (value.dim.length !== rank) {
+        if (rank === 1) {
+            throw Error("Expected a numeric vector for '" + name + "'");
+        } else if (rank === 2) {
+            throw Error("Expected a numeric matrix for '" + name + "'");
+        } else {
+            throw Error("Expected a numeric array of rank " + rank +
+                        " for '" + name + "'");
+        }
+    }
+
+    for (var i = 0; i < rank; ++i) {
+        if (value.dim[i] !== size[i + 1]) {
+            if (rank == 1) {
+                throw Error("Expected length " + size[i + 1] +
+                            " value for '" + name + "'");
+            } else {
+                throw Error("Incorrect size of dimension " + (i + 1) +
+                            " of '" + name + "' (expected " + size[i + 1] +
+                            ")");
+            }
+        }
+    }
+
+    var data = value.data.slice();
+    var len = size[0];
+    for (var i = 0; i < len; ++i) {
+        if (typeof data[i] !== "number") {
+            throw Error("Expected a number for '" + name + "'");
+        }
+        if (min !== null && data[i] < min) {
+            throw Error("Expected '" + name + "' to be at least " + min);
+        }
+        if (max !== null && data[i] > min) {
+            throw Error("Expected '" + name + "' to be at most " + max);
+        }
+    }
+
+    internal[name] = data;
+}
+
 // With arrays there are really two ways that they might come in; on
 // the one hand we could accept json-style nested arrays, which is
 // cool, but requires considerable checking.  Or, given we want
@@ -100,7 +164,7 @@ function getUserArrayDim(user, name, internal, size, defaultValue,
         size[i + 1] = value.dim[i];
     }
 
-    data = value.data.slice();
+    var data = value.data.slice();
     for (var i = 0; i < len; ++i) {
         if (typeof data[i] !== "number") {
             throw Error("Expected a number for '" + name + "'");

--- a/inst/support.js
+++ b/inst/support.js
@@ -75,19 +75,8 @@ function getUserArray(user, name, internal, size, defaultValue,
     }
 
     var rank = size.length - 1;
-    if (!(typeof value === "object" && "data" in value && "dim" in value)) {
-        throw Error("Expected an odin.js array object for '" + name + "'");
-    }
-    if (value.dim.length !== rank) {
-        if (rank === 1) {
-            throw Error("Expected a numeric vector for '" + name + "'");
-        } else if (rank === 2) {
-            throw Error("Expected a numeric matrix for '" + name + "'");
-        } else {
-            throw Error("Expected a numeric array of rank " + rank +
-                        " for '" + name + "'");
-        }
-    }
+    value = getUserArrayCheckType(value, name);
+    getUserArrayCheckRank(rank, value.dim.length, name);
 
     for (var i = 0; i < rank; ++i) {
         if (value.dim[i] !== size[i + 1]) {
@@ -102,21 +91,9 @@ function getUserArray(user, name, internal, size, defaultValue,
         }
     }
 
-    var data = value.data.slice();
-    var len = size[0];
-    for (var i = 0; i < len; ++i) {
-        if (typeof data[i] !== "number") {
-            throw Error("Expected a number for '" + name + "'");
-        }
-        if (min !== null && data[i] < min) {
-            throw Error("Expected '" + name + "' to be at least " + min);
-        }
-        if (max !== null && data[i] > min) {
-            throw Error("Expected '" + name + "' to be at most " + max);
-        }
-    }
+    getUserArrayCheckContents(value.data, min, max, isInteger, name);
 
-    internal[name] = data;
+    internal[name] = value.data.slice();
 }
 
 // With arrays there are really two ways that they might come in; on
@@ -144,19 +121,9 @@ function getUserArrayDim(user, name, internal, size, defaultValue,
     }
 
     var rank = size.length - 1;
-    if (!(typeof value === "object" && "data" in value && "dim" in value)) {
-        throw Error("Expected an odin.js array object for '" + name + "'");
-    }
-    if (value.dim.length !== rank) {
-        if (rank === 1) {
-            throw Error("Expected a numeric vector for '" + name + "'");
-        } else if (rank === 2) {
-            throw Error("Expected a numeric matrix for '" + name + "'");
-        } else {
-            throw Error("Expected a numeric array of rank " + rank +
-                        " for '" + name + "'");
-        }
-    }
+    value = getUserArrayCheckType(value, name);
+    getUserArrayCheckRank(rank, value.dim.length, name);
+    getUserArrayCheckContents(value.data, min, max, isInteger, name);
 
     var len = value.data.length;
     size[0] = len;
@@ -164,8 +131,34 @@ function getUserArrayDim(user, name, internal, size, defaultValue,
         size[i + 1] = value.dim[i];
     }
 
-    var data = value.data.slice();
-    for (var i = 0; i < len; ++i) {
+    internal[name] = value.data.slice();;
+}
+
+
+function getUserArrayCheckType(value, name) {
+    if (!(typeof value === "object" && "data" in value && "dim" in value)) {
+        throw Error("Expected an odin.js array object for '" + name + "'");
+    }
+    return value;
+}
+
+
+function getUserArrayCheckRank(expected, given, name) {
+    if (given !== expected) {
+        if (expected === 1) {
+            throw Error("Expected a numeric vector for '" + name + "'");
+        } else if (expected === 2) {
+            throw Error("Expected a numeric matrix for '" + name + "'");
+        } else {
+            throw Error("Expected a numeric array of rank " + expected +
+                        " for '" + name + "'");
+        }
+    }
+}
+
+
+function getUserArrayCheckContents(data, min, max, isInteger, name) {
+    for (var i = 0; i < data.length; ++i) {
         if (typeof data[i] !== "number") {
             throw Error("Expected a number for '" + name + "'");
         }
@@ -176,9 +169,8 @@ function getUserArrayDim(user, name, internal, size, defaultValue,
             throw Error("Expected '" + name + "' to be at most " + max);
         }
     }
-
-    internal[name] = data;
 }
+
 
 function isMissing(x) {
     return x === undefined || x === null ||

--- a/inst/support.js
+++ b/inst/support.js
@@ -43,7 +43,7 @@ function getUser(user, name, internal, size, defaultValue,
         }
     } else {
         if (typeof value !== "number") {
-            throw Error("Expected a number for '" + name + "'");
+            throw Error("Expected a numeric value for '" + name + "'");
         }
         if (min !== null && value < min) {
             throw Error("Expected '" + name + "' to be at least " + min);
@@ -164,7 +164,7 @@ function getUserArrayCheckRank(expected, given, name) {
 function getUserArrayCheckContents(data, min, max, isInteger, name) {
     for (var i = 0; i < data.length; ++i) {
         if (typeof data[i] !== "number") {
-            throw Error("Expected a number for '" + name + "'");
+            throw Error("Expected a numeric value for '" + name + "'");
         }
         if (min !== null && data[i] < min) {
             throw Error("Expected '" + name + "' to be at least " + min);

--- a/inst/support.js
+++ b/inst/support.js
@@ -56,5 +56,6 @@ function getUser(user, name, internal, size, defaultValue,
 }
 
 function isMissing(x) {
-    return x === undefined || x === null || isNaN(x);
+    return x === undefined || x === null ||
+        (typeof x === "number" && isNaN(x));
 }

--- a/inst/support.js
+++ b/inst/support.js
@@ -185,23 +185,11 @@ function isMissing(x) {
 }
 
 
-// These get replaced with generated versions shortly
+// Ranks 2..8 created by scripts/create_support_sum_js.R
 function odinSum1(x, from, to) {
     var tot = 0.0;
     for (var i = from; i < to; ++i) {
         tot += x[i];
     }
     return tot;
-}
-
-
-function odinSum2(x, from_i, to_i, from_j, to_j, dim_x_1) {
-  var tot = 0.0;
-  for (var j = from_j; j < to_j; ++j) {
-    var jj = j * dim_x_1;
-    for (var i = from_i; i < to_i; ++i) {
-        tot += x[i + jj];
-    }
-  }
-  return tot;
 }

--- a/inst/support.js
+++ b/inst/support.js
@@ -185,9 +185,11 @@ function isMissing(x) {
 }
 
 
-// Travis has ancient v8 version that lacks Number.isNumber
+// Travis has ancient v8 version that lacks Number.isNumber.  However
+// it also lacks Number.EPSILON so I'm just comparing against 1e-8
+// which is close enough to sqrt(double.eps) anyway
 function numberIsInteger(x) {
-    return Math.abs(x - Math.round(x)) < Math.sqrt(Number.EPSILON)
+    return Math.abs(x - Math.round(x)) < 1e-8
 }
 
 

--- a/inst/support.js
+++ b/inst/support.js
@@ -55,6 +55,67 @@ function getUser(user, name, internal, size, defaultValue,
     }
 }
 
+// With arrays there are really two ways that they might come in; on
+// the one hand we could accept json-style nested arrays, which is
+// cool, but requires considerable checking.  Or, given we want
+// C-style arrays ultimately we could use an R-style construct like:
+// {"data": <array>, "dim": <array>}.  I'm doing the latter for now,
+// and we can revisit later.
+function getUserArrayDim(user, name, internal, size, defaultValue,
+                         min, max, isInteger) {
+    var value = user[name];
+
+    if (isMissing(value)) {
+        if (isMissing(internal[name])) {
+            if (defaultValue === null) {
+                throw Error("Expected a value for '" + name + "'");
+            } else {
+                // not totally clear how to do this as we need to get
+                // the previous dimensions too!
+                throw Error("This needs implementing....");
+                internal[name] = defaultValue;
+            }
+        }
+        return;
+    }
+
+    var rank = size.length - 1;
+    if (!(typeof value === "object" && "data" in value && "dim" in value)) {
+        throw Error("Expected an odin.js array object for '" + name + "'");
+    }
+    if (value.dim.length !== rank) {
+        if (rank === 1) {
+            throw Error("Expected a numeric vector for '" + name + "'");
+        } else if (rank === 2) {
+            throw Error("Expected a numeric matrix for '" + name + "'");
+        } else {
+            throw Error("Expected a numeric array of rank " + rank +
+                        " for '" + name + "'");
+        }
+    }
+
+    var len = value.data.length;
+    size[0] = len;
+    for (var i = 0; i < rank; ++i) {
+        size[i + 1] = value.dim[i];
+    }
+
+    data = value.data.slice();
+    for (var i = 0; i < len; ++i) {
+        if (typeof data[i] !== "number") {
+            throw Error("Expected a number for '" + name + "'");
+        }
+        if (min !== null && data[i] < min) {
+            throw Error("Expected '" + name + "' to be at least " + min);
+        }
+        if (max !== null && data[i] > min) {
+            throw Error("Expected '" + name + "' to be at most " + max);
+        }
+    }
+
+    internal[name] = data;
+}
+
 function isMissing(x) {
     return x === undefined || x === null ||
         (typeof x === "number" && isNaN(x));

--- a/inst/support.js
+++ b/inst/support.js
@@ -183,3 +183,25 @@ function isMissing(x) {
     return x === undefined || x === null ||
         (typeof x === "number" && isNaN(x));
 }
+
+
+// These get replaced with generated versions shortly
+function odinSum1(x, from, to) {
+    var tot = 0.0;
+    for (var i = from; i < to; ++i) {
+        tot += x[i];
+    }
+    return tot;
+}
+
+
+function odinSum2(x, from_i, to_i, from_j, to_j, dim_x_1) {
+  var tot = 0.0;
+  for (var j = from_j; j < to_j; ++j) {
+    var jj = j * dim_x_1;
+    for (var i = from_i; i < to_i; ++i) {
+        tot += x[i + jj];
+    }
+  }
+  return tot;
+}

--- a/inst/support_sum.js
+++ b/inst/support_sum.js
@@ -1,0 +1,133 @@
+function odinSum2(x, iFrom, iTo, jFrom, jTo, dim1) {
+  var tot = 0.0;
+  for (var j = jFrom; j < jTo; ++j) {
+    var jj = j * dim1;
+    for (var i = iFrom; i < iTo; ++i) {
+      tot += x[i + jj];
+    }
+  }
+  return tot;
+}
+function odinSum3(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, dim1, dim12) {
+  var tot = 0.0;
+  for (var k = kFrom; k < kTo; ++k) {
+    var kk = k * dim12;
+    for (var j = jFrom; j < jTo; ++j) {
+      var jj = j * dim1 + kk;
+      for (var i = iFrom; i < iTo; ++i) {
+        tot += x[i + jj];
+      }
+    }
+  }
+  return tot;
+}
+function odinSum4(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, lFrom, lTo, dim1, dim12, dim123) {
+  var tot = 0.0;
+  for (var l = lFrom; l < lTo; ++l) {
+    var ll = l * dim123;
+    for (var k = kFrom; k < kTo; ++k) {
+      var kk = k * dim12 + ll;
+      for (var j = jFrom; j < jTo; ++j) {
+        var jj = j * dim1 + kk;
+        for (var i = iFrom; i < iTo; ++i) {
+          tot += x[i + jj];
+        }
+      }
+    }
+  }
+  return tot;
+}
+function odinSum5(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, lFrom, lTo, i5From, i5To, dim1, dim12, dim123, dim1234) {
+  var tot = 0.0;
+  for (var i5 = i5From; i5 < i5To; ++i5) {
+    var i5i5 = i5 * dim1234;
+    for (var l = lFrom; l < lTo; ++l) {
+      var ll = l * dim123 + i5i5;
+      for (var k = kFrom; k < kTo; ++k) {
+        var kk = k * dim12 + ll;
+        for (var j = jFrom; j < jTo; ++j) {
+          var jj = j * dim1 + kk;
+          for (var i = iFrom; i < iTo; ++i) {
+            tot += x[i + jj];
+          }
+        }
+      }
+    }
+  }
+  return tot;
+}
+function odinSum6(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, lFrom, lTo, i5From, i5To, i6From, i6To, dim1, dim12, dim123, dim1234, dim12345) {
+  var tot = 0.0;
+  for (var i6 = i6From; i6 < i6To; ++i6) {
+    var i6i6 = i6 * dim12345;
+    for (var i5 = i5From; i5 < i5To; ++i5) {
+      var i5i5 = i5 * dim1234 + i6i6;
+      for (var l = lFrom; l < lTo; ++l) {
+        var ll = l * dim123 + i5i5;
+        for (var k = kFrom; k < kTo; ++k) {
+          var kk = k * dim12 + ll;
+          for (var j = jFrom; j < jTo; ++j) {
+            var jj = j * dim1 + kk;
+            for (var i = iFrom; i < iTo; ++i) {
+              tot += x[i + jj];
+            }
+          }
+        }
+      }
+    }
+  }
+  return tot;
+}
+function odinSum7(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, lFrom, lTo, i5From, i5To, i6From, i6To, i7From, i7To, dim1, dim12, dim123, dim1234, dim12345, dim123456) {
+  var tot = 0.0;
+  for (var i7 = i7From; i7 < i7To; ++i7) {
+    var i7i7 = i7 * dim123456;
+    for (var i6 = i6From; i6 < i6To; ++i6) {
+      var i6i6 = i6 * dim12345 + i7i7;
+      for (var i5 = i5From; i5 < i5To; ++i5) {
+        var i5i5 = i5 * dim1234 + i6i6;
+        for (var l = lFrom; l < lTo; ++l) {
+          var ll = l * dim123 + i5i5;
+          for (var k = kFrom; k < kTo; ++k) {
+            var kk = k * dim12 + ll;
+            for (var j = jFrom; j < jTo; ++j) {
+              var jj = j * dim1 + kk;
+              for (var i = iFrom; i < iTo; ++i) {
+                tot += x[i + jj];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return tot;
+}
+function odinSum8(x, iFrom, iTo, jFrom, jTo, kFrom, kTo, lFrom, lTo, i5From, i5To, i6From, i6To, i7From, i7To, i8From, i8To, dim1, dim12, dim123, dim1234, dim12345, dim123456, dim1234567) {
+  var tot = 0.0;
+  for (var i8 = i8From; i8 < i8To; ++i8) {
+    var i8i8 = i8 * dim1234567;
+    for (var i7 = i7From; i7 < i7To; ++i7) {
+      var i7i7 = i7 * dim123456 + i8i8;
+      for (var i6 = i6From; i6 < i6To; ++i6) {
+        var i6i6 = i6 * dim12345 + i7i7;
+        for (var i5 = i5From; i5 < i5To; ++i5) {
+          var i5i5 = i5 * dim1234 + i6i6;
+          for (var l = lFrom; l < lTo; ++l) {
+            var ll = l * dim123 + i5i5;
+            for (var k = kFrom; k < kTo; ++k) {
+              var kk = k * dim12 + ll;
+              for (var j = jFrom; j < jTo; ++j) {
+                var jj = j * dim1 + kk;
+                for (var i = iFrom; i < iTo; ++i) {
+                  tot += x[i + jj];
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return tot;
+}

--- a/scripts/create_support_sum_js.R
+++ b/scripts/create_support_sum_js.R
@@ -1,0 +1,4 @@
+#!/usr/bin/env Rscript
+devtools::load_all()
+code <- unlist(lapply(2:8, generate_js_support_sum))
+writeLines(code, "inst/support_sum.js")

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -1,3 +1,5 @@
+options(odin.no_check_naked_index = TRUE)
+
 sort_list <- function(x) {
   x[order(names(x))]
 }
@@ -20,4 +22,9 @@ odin_js_support <- function() {
   support <- package_js("support.js")
   v8$eval(support)
   v8
+}
+
+
+expect_js_error <- function(...) {
+  testthat::expect_error(..., class = "std::runtime_error")
 }

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -13,3 +13,11 @@ call_odin_bundle <- function(context, name, user, t, y = NULL) {
   colnames(res$y) <- res$names
   res$y
 }
+
+
+odin_js_support <- function() {
+  v8 <- V8::v8()
+  support <- package_js("support.js")
+  v8$eval(support)
+  v8
+}

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -108,3 +108,51 @@ test_that("user variables", {
   expect_equal(mod$contents()$r, pi)
   expect_equal(mod$contents()$N0, exp(1))
 })
+
+
+test_that("discrete models are not supported", {
+  expect_error(
+    odin_js({
+      initial(x) <- 1
+      update(x) <- x + 1
+    }),
+    "Using unsupported features: 'discrete'")
+})
+
+
+test_that("delay models are not supported", {
+  expect_error(
+    odin_js({
+      ylag <- delay(y, 10)
+      initial(y) <- 0.5
+      deriv(y) <- 0.2 * ylag * 1 / (1 + ylag^10) - 0.1 * y
+    }),
+    "Using unsupported features: 'has_delay'")
+})
+
+
+test_that("output is not supported", {
+  expect_error(
+    odin_js({
+      y1 <- sin(t)
+      deriv(y2) <- y1
+      initial(y2) <- -1
+      output(y1) <- y1
+    }),
+    "Using unsupported features: 'has_output'")
+})
+
+
+test_that("interpolation is not supported", {
+  expect_error(
+    odin_js({
+      deriv(y) <- pulse
+      initial(y) <- 0
+      pulse <- interpolate(tp, zp, "constant")
+      tp[] <- user()
+      zp[] <- user()
+      dim(tp) <- user()
+      dim(zp) <- user()
+    }),
+    "Using unsupported features: 'has_interpolate'")
+})

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -87,13 +87,13 @@ test_that("user variables", {
   })
 
   expect_error(gen())
-  expect_error(gen(NULL),
-               "Expected a value for 'r'", fixed = TRUE,
-               class = "std::runtime_error")
-  ## expect_error(gen(1:2),
-  ##              "Expected a scalar numeric for 'r'")
-  ## expect_error(gen(numeric(0)),
-  ##              "Expected a scalar numeric for 'r'")
+  ## TODO: Some of these errors are not the same as the other engines
+  expect_js_error(gen(user = NULL),
+                  "Expected a value for 'r'", fixed = TRUE)
+  expect_js_error(gen(r = 1:2),
+                  "Expected a numeric value for 'r'")
+  expect_js_error(gen(r = numeric(0)),
+                  "Expected a numeric value for 'r'")
 
   expect_equal(sort_list(gen(r = pi)$contents()),
                sort_list(list(K = 100, N0 = 1, initial_N = 1, r = pi)))

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -257,3 +257,17 @@ test_that("array support", {
   ##                   y = yy[, 2],
   ##                   x = unname(yy[, 3:5])))
 })
+
+
+test_that("multi-line array expression", {
+  gen <- odin_js({
+    initial(x) <- 1
+    deriv(x) <- 1
+    a[1] <- 1
+    a[2] <- 1
+    a[3:n] <- a[i - 1] + a[i - 2]
+    dim(a) <- n
+    n <- 10
+  })
+  expect_equal(gen()$contents()$a, c(1, 1, 2, 3, 5, 8, 13, 21, 34, 55))
+})

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -218,8 +218,38 @@ test_that("copy output", {
 })
 
 
-## discrete
-## discrete with output
+## Basic discrete models
+test_that("discrete", {
+  skip("Needs implementing")
+  gen <- odin({
+    initial(x) <- 1
+    update(x) <- x + 1
+  })
+  mod <- gen()
+
+  expect_equal(mod$initial(), 1)
+  expect_equal(mod$update(0, 1), 2)
+
+  tt <- 0:10
+  yy <- mod$run(tt)
+  expect_equal(yy, cbind(step = tt, x = tt + 1))
+})
+
+
+test_that("discrete with output", {
+  skip("Needs implementing")
+  gen <- odin({
+    initial(x) <- 1
+    update(x) <- x + 1
+    output(y) <- x + step
+  })
+  mod <- gen()
+
+  expect_equal(mod$update(2, 3), structure(4, output = 5))
+  tt <- 0:10
+  yy <- mod$run(tt)
+  expect_equal(yy, cbind(step = tt, x = tt + 1, y = 2 * tt + 1))
+})
 
 
 ## Fairly minimal array model, though it does mix array and non array

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -271,3 +271,31 @@ test_that("multi-line array expression", {
   })
   expect_equal(gen()$contents()$a, c(1, 1, 2, 3, 5, 8, 13, 21, 34, 55))
 })
+
+
+test_that("3d array", {
+  gen <- odin_js({
+    initial(y[, , ]) <- 1
+    deriv(y[, , ]) <- y[i, j, k] * 0.1
+    dim(y) <- c(2, 3, 4)
+  })
+
+  mod <- gen()
+  d <- mod$contents()
+  ## expect_equal(d$initial_y, array(1, c(2, 3, 4))) # TODO
+  expect_equal(d$dim_y, 24)
+  expect_equal(d$dim_y_1, 2)
+  expect_equal(d$dim_y_2, 3)
+  expect_equal(d$dim_y_3, 4)
+  expect_equal(d$dim_y_12, 6)
+
+  expect_equal(mod$initial(0), rep(1, 24))
+  expect_equal(mod$deriv(0, mod$initial(0)), rep(0.1, 24))
+
+  tt <- 0:10
+  yy <- mod$run(tt, atol = 1e-8, rtol = 1e-8)
+  expect_equal(colnames(yy)[[12]], "y[1,3,2]")
+  expect_equal(yy[, 1], tt)
+  expect_equal(unname(yy[, -1]), matrix(rep(exp(0.1 * tt), 24), 11),
+               tolerance = 1e-7)
+})

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -219,7 +219,7 @@ test_that("copy output", {
 ## Basic discrete models
 test_that("discrete", {
   skip("Needs implementing")
-  gen <- odin({
+  gen <- odin_js({
     initial(x) <- 1
     update(x) <- x + 1
   })
@@ -236,7 +236,7 @@ test_that("discrete", {
 
 test_that("discrete with output", {
   skip("Needs implementing")
-  gen <- odin({
+  gen <- odin_js({
     initial(x) <- 1
     update(x) <- x + 1
     output(y) <- x + step

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -126,15 +126,13 @@ test_that("user variables", {
 
   expect_error(gen())
   ## TODO: had to change error strings here
-  expect_error(gen(NULL),
-               "Expected a value for 'r'", fixed = TRUE,
-               class = "std::runtime_error")
-  expect_error(gen(r = 1:2),
-               "Expected a value for 'r'",
-               class = "std::runtime_error")
-  expect_error(gen(numeric(0)),
-               "Expected a value for 'r'",
-               class = "std::runtime_error")
+  expect_js_error(gen(user = NULL),
+                  "Expected a value for 'r'", fixed = TRUE)
+  expect_js_error(gen(r = 1:2),
+                  "Expected a numeric value for 'r'", fixed = TRUE)
+  expect_js_error(gen(r = numeric(0)),
+                  "Expected a numeric value for 'r'",
+                  fixed = TRUE)
 
   expect_equal(sort_list(gen(r = pi)$contents()),
                sort_list(list(K = 100, N0 = 1, initial_N = 1, r = pi)))

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -253,8 +253,8 @@ test_that("array support", {
                           deparse.level = 0))
   expect_equal(colnames(yy), c("t", "y", "x[1]", "x[2]", "x[3]"))
 
-  expect_equal(mod$transform_variables(yy),
-               list(t = tt,
-                    y = yy[, 2],
-                    x = unname(yy[, 3:5])))
+  ## expect_equal(mod$transform_variables(yy),
+  ##              list(t = tt,
+  ##                   y = yy[, 2],
+  ##                   x = unname(yy[, 3:5])))
 })

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -225,7 +225,6 @@ test_that("copy output", {
 ## Fairly minimal array model, though it does mix array and non array
 ## variables, plus an array support variable.
 test_that("array support", {
-  skip("needs implementing")
   gen <- odin_js({
     initial(x[]) <- 1
     initial(y) <- 2

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -243,7 +243,7 @@ test_that("array support", {
   expect_equal(sort_list(mod$contents()),
                sort_list(list(dim_r = 3, dim_x = 3, initial_x = rep(1, 3),
                               initial_y = 2, n = 3, r = 1:3)))
-  expect_equal(mod$initial(), c(2, 1, 1, 1))
+  expect_equal(mod$initial(0), c(2, 1, 1, 1))
   expect_equal(mod$deriv(0, c(2, 1, 1, 1)), c(3, 1, 2, 3))
 
   tt <- 0:10

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -853,7 +853,6 @@ test_that("sum over one dimension", {
 })
 
 test_that("sum over two dimensions", {
-  skip("sum")
   ## This is where things get a bit more horrid:
   gen <- odin_js({
     deriv(y) <- 0
@@ -896,7 +895,7 @@ test_that("sum over two dimensions", {
 
     tot1 <- sum(a)
     tot2 <- sum(a[,,])
-  }, verbose = FALSE)
+  })
 
   nr <- 5
   nc <- 7
@@ -904,18 +903,18 @@ test_that("sum over two dimensions", {
   a <- array(runif(nr * nc * nz), c(nr, nc, nz))
   dat <- gen(a = a)$contents()
 
-  expect_equal(dat$a, a)
-  expect_equal(dat$m12, apply(a, 1:2, sum))
-  expect_equal(dat$m13, apply(a, c(1, 3), sum))
-  expect_equal(dat$m23, apply(a, 2:3, sum))
+  expect_equal(dat$a, c(a)) # TODO: reshaping all through here
+  expect_equal(dat$m12, c(apply(a, 1:2, sum)))
+  expect_equal(dat$m13, c(apply(a, c(1, 3), sum)))
+  expect_equal(dat$m23, c(apply(a, 2:3, sum)))
 
   expect_equal(dat$v1, apply(a, 1, sum))
   expect_equal(dat$v2, apply(a, 2, sum))
   expect_equal(dat$v3, apply(a, 3, sum))
 
-  expect_equal(dat$mm12, apply(a[,,2:4], 1:2, sum))
-  expect_equal(dat$mm13, apply(a[,2:4,], c(1, 3), sum))
-  expect_equal(dat$mm23, apply(a[2:4,,], 2:3, sum))
+  expect_equal(dat$mm12, c(apply(a[,,2:4], 1:2, sum)))
+  expect_equal(dat$mm13, c(apply(a[,2:4,], c(1, 3), sum)))
+  expect_equal(dat$mm23, c(apply(a[2:4,,], 2:3, sum)))
 
   expect_equal(dat$vv1, apply(a[,2:4,2:4], 1, sum))
   expect_equal(dat$vv2, apply(a[2:4,,2:4], 2, sum))

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1079,7 +1079,6 @@ test_that("c in dim for vector", {
 
 
 test_that("user variable information", {
-  skip("user arrays")
   gen <- odin_js({
     deriv(N) <- r[1] * N * (1 - N / K)
     initial(N) <- N0
@@ -1095,12 +1094,12 @@ test_that("user variable information", {
   expect_equal(info$has_default, c(FALSE, TRUE, TRUE))
   expect_equal(info$rank, c(1L, 0L, 0L))
 
+  skip("interface error")
   expect_identical(coef(gen(1)), info)
 })
 
 
 test_that("user variable information - when no user", {
-  skip("user arrays")
   gen <- odin_js({
     deriv(N) <- r * N * (1 - N / K)
     initial(N) <- N0
@@ -1118,12 +1117,12 @@ test_that("user variable information - when no user", {
                     integer = logical(),
                     stringsAsFactors = FALSE)
   expect_identical(info, cmp)
+  skip("interface issue")
   expect_identical(coef(gen()), cmp)
 })
 
 
 test_that("format/print", {
-  skip("user arrays")
   gen <- odin_js({
     deriv(N) <- r[1] * N * (1 - N / K)
     initial(N) <- N0
@@ -1170,15 +1169,18 @@ test_that("multiline string", {
 ## This is basically all ok but what is still not great is _doing_ the
 ## validation.
 test_that("user integer", {
-  skip("user integer support")
   gen <- odin_js({
     deriv(y) <- 0.5
     initial(y) <- y0
     y0 <- user(1, integer = TRUE, min = 0)
   })
 
-  expect_error(gen(y0 = 1.5), "Expected 'y0' to be integer-like")
-  expect_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
+  expect_error(gen(y0 = 1.5),
+               "Expected 'y0' to be integer-like",
+               class = "std::runtime_error")
+  expect_error(gen(y0 = -1L),
+               "Expected 'y0' to be at least 0",
+               class = "std::runtime_error")
 
   expect_error(mod <- gen(y0 = 1), NA)
   expect_equal(mod$run(0:10)[, "y"], 1.0 + 0.5 * (0:10))
@@ -1186,7 +1188,6 @@ test_that("user integer", {
 
 
 test_that("multiple constraints", {
-  skip("user constraints")
   gen <- odin_js({
     deriv(y) <- r
     initial(y) <- y0
@@ -1200,7 +1201,6 @@ test_that("multiple constraints", {
 
 
 test_that("set_user honours constraints", {
-  skip("user constraints")
   gen <- odin_js({
     deriv(y) <- r
     initial(y) <- y0
@@ -1209,8 +1209,8 @@ test_that("set_user honours constraints", {
   })
 
   mod <- gen()
-  expect_error(mod$set_user(y0 = -1L), "Expected 'y0' to be at least 0")
-  expect_error(mod$set_user(r = 100), "Expected 'r' to be at most 10")
+  expect_error(mod$set_user(list(y0 = -1L)), "Expected 'y0' to be at least 0")
+  expect_error(mod$set_user(list(r = 100)), "Expected 'r' to be at most 10")
 })
 
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -925,7 +925,6 @@ test_that("sum over two dimensions", {
 })
 
 test_that("sum for a 4d array", {
-  skip("sum")
   ## I don't want to check absolutely everything here, so hopefully if
   ## these few go OK then given the more exhaustive tests above we'll
   ## be OK
@@ -946,16 +945,16 @@ test_that("sum for a 4d array", {
 
     tot1 <- sum(a)
     tot2 <- sum(a[,,,])
-  }, verbose = FALSE)
+  })
 
   dim <- c(3, 5, 7, 9)
   a <- array(runif(prod(dim)), dim)
   dat <- gen(a = a)$contents()
 
-  expect_equal(dat$a, a)
-  expect_equal(dat$m12, apply(a, 1:2, sum))
-  expect_equal(dat$m23, apply(a, c(2, 3), sum))
-  expect_equal(dat$m24, apply(a, c(2, 4), sum))
+  expect_equal(dat$a, c(a))
+  expect_equal(dat$m12, c(apply(a, 1:2, sum)))
+  expect_equal(dat$m23, c(apply(a, c(2, 3), sum)))
+  expect_equal(dat$m24, c(apply(a, c(2, 4), sum)))
 })
 
 test_that("self output for scalar", {

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1,5 +1,157 @@
 context("run: general")
 
+## Tests of the approach against some known models.
+test_that("constant model", {
+  gen <- odin_js({
+    deriv(y) <- 0.5
+    initial(y) <- 1
+  })
+  mod <- gen()
+  ## expect_identical(r6_private(mod)$init, 1.0)
+  ## expect_identical(mod$deriv(0.0, r6_private(mod)$init), 0.5)
+
+  tt <- seq(0, 10, length.out = 11)
+  yy <- mod$run(tt)
+  expect_equal(yy[, 2L], seq(1.0, length.out = length(tt), by = 0.5))
+
+  ## Can avoid having column names:
+  expect_null(colnames(mod$run(tt, use_names = FALSE)))
+})
+
+test_that("user variables", {
+  gen <- odin_js({
+    deriv(N) <- r * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- user(1)
+    K <- user(100)
+    r <- user()
+  })
+
+  ## Two different errors when r is not provided:
+  ## expect_error(gen(), 'argument "r" is missing')
+  ## expect_error(gen(NULL), "Expected a value for 'r'")
+
+  mod <- gen(r = pi) # TODO: arg name r= should not be required
+  dat <- mod$contents()
+  expect_equal(dat$r, pi)
+  expect_equal(dat$N0, 1.0)
+  expect_equal(dat$K, 100.0)
+
+  ## This should be a noop:
+  mod$set_user(NULL)
+  dat <- mod$contents()
+  expect_equal(dat$r, pi)
+  expect_equal(dat$N0, 1.0)
+  expect_equal(dat$K, 100.0)
+
+  ## Now, try setting one of these:
+  mod$set_user(list(N0 = 5)) # TODO: different interface
+  dat <- mod$contents()
+  expect_equal(dat$r, pi)
+  expect_equal(dat$N0, 5.0)
+  expect_equal(dat$K, 100.0)
+
+  ## Don't reset to default on subsequent set:
+  mod$set_user(NULL)
+  expect_equal(mod$contents()$N0, 5.0)
+})
+
+test_that("user variables on models with none", {
+  skip("needs work")
+  gen <- odin_js({
+    a <- 1
+    deriv(y) <- 0.5 * a
+    initial(y) <- 1
+  })
+  expect_error(gen(a = 1), "unused argument")
+  mod <- gen()
+  ## NOTE: This is a change of behaviour, but that's probably OK
+  expect_silent(mod$set_user())
+  expect_warning(mod$set_user(a = 1), "Unknown user parameters: a")
+})
+
+test_that("non-numeric time", {
+  skip("needs delay")
+  ## Only an issue for delay models or models with time-dependent
+  ## initial conditions.
+  gen <- odin_js({
+    ylag <- delay(y, 10)
+    initial(y) <- 0.5
+    deriv(y) <- 0.2 * ylag * 1 / (1 + ylag^10) - 0.1 * y
+  })
+  mod <- gen()
+  t <- as.integer(0:10)
+  expect_equal(mod$initial(t), 0.5)
+  expect_silent(mod$run(t))
+})
+
+test_that("delays and initial conditions", {
+  skip("needs delay")
+  gen <- odin_js({
+    ylag <- delay(y, 10)
+    initial(y) <- 0.5
+    deriv(y) <- 0.2 * ylag * 1 / (1 + ylag^10) - 0.1 * y
+  })
+
+  mod <- gen()
+  t <- as.integer(0:10)
+  res1 <- mod$run(t)
+
+  dat <- mod$contents()
+  expect_equal(dat$initial_t, 0.0)
+  expect_equal(dat$initial_y, 0.5)
+
+  res2 <- mod$run(t + 1)
+  expect_equal(res2[, 2], res1[, 2])
+  expect_equal(mod$contents()$initial_t, 1.0)
+
+  ## Trickier; pass the initial conditions through and have them set
+  ## into the model so delays work correctly.
+  res3 <- mod$run(t + 2, 0.5)
+  expect_equal(res3[, 2], res1[, 2], tolerance = 1e-7)
+  expect_equal(mod$contents()$initial_t, 2.0)
+  expect_equal(mod$contents()$initial_y, 0.5)
+
+  res4 <- mod$run(t + 3, 0.6)
+
+  expect_equal(mod$contents()$initial_t, 3.0)
+  expect_equal(mod$contents()$initial_y, 0.6)
+  expect_false(isTRUE(all.equal(res4[, 2], res1[, 2])))
+})
+
+test_that("non-numeric user", {
+  skip("needs work")
+  gen <- odin_js({
+    deriv(N) <- r * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- user(1)
+    K <- user(100)
+    r <- user()
+  })
+  mod <- gen(r = 1L)
+  expect_is(mod$contents()$r, "numeric")
+  expect_identical(mod$contents()$r, 1.0)
+})
+
+
+test_that("conditionals", {
+  ## TODO: this fails if initial(x) is set to zero, like in the odin
+  ## test, due to integration not starting.  This is a general problem
+  ## in the underlying solver.
+  gen <- odin_js({
+    deriv(x) <- if (x > 2) 0 else 0.5
+    initial(x) <- 1
+  })
+
+  ## Hey ho it works:
+  mod <- gen()
+  t <- seq(0, 5, length.out = 101)
+  y <- mod$run(t)
+
+  expect_equal(y[, 2], ifelse(t < 2, t * 0.5 + 1, 2.0), tolerance = 1e-4)
+})
+
+
 test_that("conditionals, precendence", {
   ## TODO: this fails if initial(x) is set to zero, like in the odin
   ## test, due to integration not starting.  This is a general problem
@@ -15,4 +167,1122 @@ test_that("conditionals, precendence", {
 
   cmp <- ifelse(t < 2, 1.1 * t, 2.4 -0.1 * t) + 1
   expect_equal(y[, 2], cmp, tolerance = 1e-4)
+})
+
+
+test_that("time dependent", {
+  ## A time dependent initial condition:
+  gen_t <- odin_js({
+    deriv(N) <- r * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- sqrt(t) + 1
+    K <- 100
+    r <- 0.5
+  })
+
+  ## The same model, but taking N0 as a user parameter.
+  gen_cmp <- odin_js({
+    deriv(N) <- r * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- user()
+    K <- 100
+    r <- 0.5
+  })
+
+  mod_t <- gen_t()
+  expect_equal(mod_t$initial(0), 1)
+  expect_equal(mod_t$initial(10), sqrt(10) + 1)
+
+  t0 <- seq(0,  10, length.out = 101)
+  t1 <- seq(10, 20, length.out = 101) # TODO: changed this.
+
+  expect_equal(mod_t$run(t0), gen_cmp(N0 = sqrt(t0[[1]]) + 1)$run(t0))
+  expect_equal(mod_t$run(t1), gen_cmp(N0 = sqrt(t1[[1]]) + 1)$run(t1))
+})
+
+test_that("time dependent initial conditions", {
+  skip("output")
+  gen <- odin_js({
+    y1 <- sin(t)
+    deriv(y2) <- y1
+    initial(y2) <- -1
+    output(y1) <- y1
+  })
+
+  mod <- gen()
+  t <- seq(0, 2 * pi, length.out = 101)
+  y <- mod$run(t, atol = 1e-8, rtol = 1e-8)
+  expect_identical(y[, 3L], sin(t))
+  expect_equal(y[, 2L], cos(t + pi), tolerance = 1e-6)
+})
+
+test_that("user c", {
+  skip("never going to use this")
+  skip_for_target("r")
+  gen <- odin_js({
+    config(include) <- "user_fns.c"
+    z <- squarepulse(t, 1, 2)
+    output(z) <- z
+    deriv(y) <- z
+    initial(y) <- 0
+  })
+
+  mod <- gen()
+  t <- seq(0, 3, length.out = 301)
+  y <- mod$run(t)
+
+  expect_equal(y[, 3L], as.numeric(t >= 1 & t < 2))
+  cmp <- -1 + t
+  cmp[t < 1] <- 0
+  cmp[t > 2] <- 1
+  expect_equal(y[, 2L], cmp, tolerance = 1e-5)
+})
+
+test_that("user c in subdir", {
+  skip("never going to use this")
+  skip_for_target("r")
+  dest <- tempfile()
+  dir.create(dest)
+
+  expr <- c('config(include) <- "myfuns.c"',
+            "z <- squarepulse(t, 1, 2)",
+            "output(z) <- z",
+            "deriv(y) <- z",
+            "initial(y) <- 0")
+  test <- file.path(dest, "test.R")
+  writeLines(expr, test)
+
+  expect_error(odin_(test), "Could not find file 'myfuns.c'",
+               class = "odin_error")
+
+  file.copy("user_fns.c", file.path(dest, "myfuns.c"))
+  gen <- odin_(test)
+
+  ## copied from above:
+  mod <- gen()
+  t <- seq(0, 3, length.out = 301)
+  y <- mod$run(t)
+
+  expect_equal(y[, 3L], as.numeric(t >= 1 & t < 2))
+  cmp <- -1 + t
+  cmp[t < 1] <- 0
+  cmp[t > 2] <- 1
+  expect_equal(y[, 2L], cmp, tolerance = 1e-5)
+})
+
+test_that("time dependent initial conditions", {
+  skip("needs output")
+  gen <- odin_js({
+    y1 <- cos(t)
+    y2 <- y1 * (1 + t)
+    deriv(y3) <- y2
+    initial(y3) <- y2
+    output(y1) <- y1
+    output(y2) <- y2
+  })
+
+  mod <- gen()
+
+  ## Initial conditions get through here:
+  expect_equivalent(mod$initial(0), 1)
+  expect_equivalent(mod$initial(1), cos(1) * 2)
+
+  t <- seq(0, 4 * pi, length.out = 101)
+  y <- mod$run(t, atol = 1e-8, rtol = 1e-8)
+  expect_equal(as.vector(y[1, 2]), 1.0)
+  ## TODO: Compute analytic expectation and compare here.
+  expect_equal(as.vector(y[length(t), 2]), 1.0, tolerance = 1e-7)
+})
+
+test_that("time dependent initial conditions depending on vars", {
+  gen <- odin_js({
+    v1 <- exp(-t)
+
+    initial(y1) <- 1
+    deriv(y1) <- y1 * v1
+
+    deriv(y2) <- y2 * 0.5
+    initial(y2) <- y1 + v1
+
+    deriv(y3) <- y3 * 0.1
+    initial(y3) <- y1 + y2
+  })
+
+  mod <- gen()
+  expect_equal(mod$initial(0), c(1, 2, 3))
+  expect_equal(mod$initial(1), c(1, 1 + exp(-1), 2 + exp(-1)))
+})
+
+## This test case kindly contributed by @blackedder in #14
+test_that("unused variable in output", {
+  skip("needs output")
+  gen <- odin_js({
+    initial(S) <- N - I0
+    initial(E1) <- 0
+    initial(E2) <- 0
+    initial(I1) <- I0
+    initial(I2) <- 0
+    initial(R) <- 0
+
+    N <- 1e7
+    I0 <- 1
+
+    lambda <- 0.00001 * (I1 + I2)
+    gamma1 <- 2.5
+    gamma2 <- 1.1
+
+    deriv(S) <- -lambda * S
+    deriv(E1) <- lambda * S - gamma1 * E1
+    deriv(E2) <- gamma1 * (E1 - E2)
+    deriv(I1) <- gamma1 * E2  - gamma2 * I1
+    deriv(I2) <- gamma2 * (I1 - I2)
+    deriv(R) <- gamma2 * I2
+
+    output(tot) <- S + E1 + E2 + I1 + I2 + R
+  })
+  mod <- gen()
+  expect_is(mod, "odin_model")
+  t <- seq(0, 10, length.out = 100)
+  expect_error(mod$run(t), NA)
+})
+
+test_that("3d array", {
+  gen <- odin_js({
+    initial(y[,,]) <- 1
+    deriv(y[,,]) <- y[i,j,k] * 0.1
+    dim(y) <- c(2, 3, 4)
+  })
+  mod <- gen()
+  expect_equal(mod$initial(0), rep(1.0, 2 * 3 * 4))
+
+  tt <- seq(0, 10, length.out = 11)
+  yy <- mod$run(tt)
+
+  ## We now have nicely named output:
+  expect_match(colnames(yy)[-1], "^y\\[[0-9],[0-9],[0-9]\\]$")
+
+  ## Transform for even nicer:
+  ## zz <- mod$transform_variables(yy)
+  ## expect_equal(dim(zz$y), c(c(length(tt), 2, 3, 4)))
+
+  ## Check the automatic variable naming:
+  ## expect_identical(zz$y[, 1, 2, 4], yy[, "y[1,2,4]"])
+
+  ## Check conversion of single row:
+  ## y0 <- mod$transform_variables(yy[1,])
+  ## expect_equal(y0,
+  ##              c(setNames(list(tt[1]), TIME), list(y = array(1, c(2, 3, 4)))))
+})
+
+test_that("4d array", {
+  ## TODO: offset_y is saved here and is not really needed.
+  gen <- odin_js({
+    initial(y[,,,]) <- 1
+    deriv(y[,,,]) <- y[i,j,k,l] * 0.1
+    dim(y) <- c(2, 3, 4, 5)
+  })
+
+  mod <- gen()
+  expect_equal(mod$initial(0), rep(1.0, 2 * 3 * 4 * 5))
+  ## TODO:
+  ## dat <- mod$contents()
+  ## expect_equal(dat$initial_y, array(1, c(2, 3, 4, 5)))
+})
+
+## I need a system with mixed variables and arrays for testing the
+## parse code.  This is going to be a really stupid system!
+test_that("mixed", {
+  gen <- odin_js({
+    deriv(a) <- r * a
+    initial(a) <- 1
+    deriv(b) <- r * b
+    initial(b) <- 1
+    deriv(v[]) <- r * v[i]
+    initial(v[]) <- 1
+    dim(v) <- 3
+    r <- 0.1
+  })
+  mod <- gen()
+  expect_is(mod, "odin_model")
+  t <- seq(0, 10, length.out = 100)
+  y <- mod$run(t)
+  expect_error(y, NA) # just test that it doesn't fail
+
+  ## yy <- mod$transform_variables(y)
+  ## expect_equal(sort(names(yy)), sort(c(TIME, "a", "b", "v")))
+
+  ## Check contents:
+  ## expect_equal(yy[c(TIME, "a", "b")],
+  ##              as.list(as.data.frame(y[, c(TIME, "a", "b")])))
+  ## expect_equal(yy$v, unname(y[, sprintf("v[%d]", 1:3)]))
+
+  ## Check scalar:
+  ## y0 <- mod$transform_variables(y[1, ])
+  ## expect_equal(names(y0), names(yy))
+  ## expect_equal(y0,
+  ##              lapply(yy, function(x) if (is.matrix(x)) x[1, ] else x[[1]]))
+})
+
+
+## TODO: We're ambiguous with output dim.
+##
+## This would probably work but be bad:
+##
+##   output(y[]) <- y[i] * 2
+##   dim(y) <- 10
+##
+## because we'd pick up dim(output(y)) as 10; most of the time this
+## would be correct but sometimes might not be.  The check is:
+##
+## disallow *array* output that is nontrivial that shares a name with
+## any other variable.
+
+## Output array
+##
+## (1) A new array:
+test_that("output array", {
+  skip("needs output")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- 1
+    r[] <- 0.1
+    dim(r) <- 3
+    dim(y) <- 3
+    ## testing below here:
+    output(y2[]) <- y[i] * 2
+    ## NOTE: Not dim(output(y2)) [TODO: should we support this?]
+    dim(y2) <- 3 # length(y) -- TODO -- should be OK?
+  })
+
+  mod <- gen()
+  tt <- seq(0, 10, length.out = 101)
+  yy <- mod$run(tt)
+
+  expect_equal(colnames(yy), c("t",
+                               sprintf("y[%d]", 1:3),
+                               sprintf("y2[%d]", 1:3)))
+
+  ## transform function:
+  zz <- mod$transform_variables(yy)
+  expect_equal(zz$y2, zz$y * 2)
+})
+
+## (2) An existing array
+test_that("output array", {
+  skip("needs output")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- 1
+    r[] <- 0.1
+    dim(r) <- 3
+    dim(y) <- 3
+    ## This should probably be OK, but might need some more trickery...
+    output(r[]) <- r
+  })
+
+  mod <- gen()
+  tt <- seq(0, 10, length.out = 101)
+  yy <- mod$run(tt)
+
+  expect_equal(colnames(yy), c("t",
+                               sprintf("y[%d]", 1:3),
+                               sprintf("r[%d]", 1:3)))
+
+  ## transform function:
+  zz <- mod$transform_variables(yy)
+  expect_equal(zz$r, matrix(0.1, length(tt), 3))
+})
+
+
+test_that("use length on rhs", {
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- 1
+    r[] <- 0.1
+    dim(y) <- 3
+    dim(r) <- length(y)
+  })
+
+  mod <- gen()
+  expect_equal(mod$contents()$r, rep(0.1, 3))
+})
+
+test_that("use dim on rhs", {
+  gen <- odin_js({
+    deriv(y[,]) <- r[i] * y[i,j]
+    initial(y[,]) <- 1
+    r[] <- 0.1
+    dim(y) <- c(3, 4)
+    dim(r) <- dim(y, 1)
+  })
+
+  mod <- gen()
+  expect_equal(mod$contents()$r, rep(0.1, 3))
+  expect_equal(mod$contents()$initial_y, rep(1, 3 * 4)) # TODO: return matrix
+})
+
+
+## Ideally we'll end up with all combinations of has array/has scalar
+## (there are 15 possible combinations though!)
+test_that("transform variables with output", {
+  skip("transform_variables")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- y0[i]
+    r[] <- user()
+    dim(r) <- user()
+    dim(y) <- length(r)
+    y0[] <- user()
+    dim(y0) <- length(r)
+    output(a) <- sum(y)
+  })
+
+  y0 <- runif(3)
+  r <- runif(3)
+  mod <- gen(y0 = y0, r = r)
+
+  tt <- seq(0, 5, length.out = 101)
+  real_y <- t(y0 * exp(outer(r, tt)))
+  real_a <- rowSums(real_y)
+
+  y <- mod$run(tt, atol = 1e-8, rtol = 1e-8)
+  yy <- mod$transform_variables(y)
+
+  expect_equal(yy$y, real_y)
+  expect_equal(yy$a, real_a)
+})
+
+
+test_that("transform variables without time", {
+  skip("transform_variables")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- y0[i]
+    r[] <- user()
+    dim(r) <- user()
+    dim(y) <- length(r)
+    y0[] <- user()
+    dim(y0) <- length(r)
+    output(a) <- sum(y)
+  })
+
+  y0 <- runif(3)
+  r <- runif(3)
+  mod <- gen(y0 = y0, r = r)
+
+  tt <- seq(0, 5, length.out = 101)
+  yy <- mod$run(tt, atol = 1e-8, rtol = 1e-8)
+
+  cmp <- mod$transform_variables(yy)
+  res <- mod$transform_variables(yy[, -1])
+  expect_equal(names(res), names(cmp))
+  expect_equal(res$t, rep(NA_real_, length(tt)))
+  expect_equal(res[names(res) != "t"], cmp[names(cmp) != "t"])
+
+  cmp <- mod$transform_variables(yy[1, ])
+  res <- mod$transform_variables(yy[1, -1])
+  expect_equal(names(res), names(cmp))
+  expect_equal(res$t, NA_real_)
+  expect_equal(res[names(res) != "t"], cmp[names(cmp) != "t"])
+
+  expect_error(mod$transform_variables(yy[, -(1:2)]),
+               "Unexpected size input")
+  expect_error(mod$transform_variables(cbind(yy, yy)),
+               "Unexpected size input")
+})
+
+
+test_that("pathalogical array index", {
+  gen <- odin_js({
+    deriv(z) <- y1 + y2 + y3 + y4 + y5
+    initial(z) <- 0
+
+    ## This one is a bit of a worry, frankly - everything is off by
+    ## one.  It looks to me that the issue here is that in the
+    ## *initial assignment* we have assigned the wrong thing.  I think
+    ## that Ada has an issue about this actually!  Probably this will
+    ## require some care on the rewrite.
+    y[] <- i #  + 1
+    dim(y) <- 5
+
+    a <- length(y)
+
+    y1 <- y[a + 1 - a] # y[1] -- first call is '-'
+    y2 <- y[2 - a + a] # y[2] -- first call is '+'
+    y3 <- y[1 + 2] # y[3]
+    y4 <- y[a - 1] # y[4]
+    y5 <- y[5 + (a - a)] # y[5]
+  })
+
+  dat <- gen()$contents()
+  expect_equal(dat$y1, 1.0)
+  expect_equal(dat$y2, 2.0)
+  expect_equal(dat$y3, 3.0)
+  expect_equal(dat$y4, 4.0)
+  expect_equal(dat$y5, 5.0)
+})
+
+
+test_that("two output arrays", {
+  skip("needs output")
+  gen <- odin_js({
+    deriv(y[]) <- y[i] * r[i]
+    initial(y[]) <- i
+    dim(y) <- 3
+    dim(r) <- 3
+    r[] <- user()
+    output(yr[]) <- y[i] / i
+    dim(yr) <- 3
+    output(r[]) <- TRUE
+  })
+
+  r <- runif(3)
+  mod <- gen(r = r)
+  tt <- seq(0, 10, length.out = 101)
+  yy <- mod$run(tt, atol = 1e-8, rtol = 1e-8)
+  zz <- mod$transform_variables(yy)
+
+  expect_equal(zz$y, t(1:3 * exp(outer(r, tt))), tolerance = 1e-6)
+  expect_equal(zz$r, matrix(r, length(tt), 3, TRUE))
+  expect_equal(zz$yr, t(t(zz$y) / (1:3)))
+
+  ## An extension of the above that tickles an array size problem
+  gen2 <- odin_js({
+    deriv(y[]) <- y[i] * r[i]
+    initial(y[]) <- y0[i]
+    dim(y) <- length(y0)
+    dim(r) <- length(y0)
+    y0[] <- user()
+    r[] <- user()
+    dim(y0) <- user()
+    output(yr[]) <- y[i] / y0[i]
+    dim(yr) <- length(y0)
+    output(r[]) <- TRUE
+  })
+
+  mod2 <- gen2(y0 = as.numeric(1:3), r = r)
+  res <- mod2$run(tt, atol = 1e-8, rtol = 1e-8)
+  expect_equal(res, yy)
+})
+
+## TODO: This still needs harmonising with get_user_array1 functions
+## (non user dimensions) as they use coerceVector still.
+test_that("non-numeric input", {
+  skip("needs user dimension support")
+  gen <- odin_js({
+    deriv(y) <- 1
+    initial(y) <- 1
+    scalar <- user()
+    vector[] <- user()
+    dim(vector) <- user()
+    matrix[,] <- user()
+    dim(matrix) <- user()
+    array[,,] <- user()
+    dim(array) <- user()
+    array4[,,,] <- user()
+    dim(array4) <- user()
+  })
+
+  scalar <- 1
+  vector <- as.numeric(1:3)
+  matrix <- matrix(as.numeric(1:prod(2:3)), 2L, 3L)
+  array <- array(as.numeric(1:prod(2:4)), c(2L, 3L, 4L))
+  array4 <- array(as.numeric(1:prod(2:5)), c(2L, 3L, 4L, 5L))
+
+  convert <- function(x, to = "integer") {
+    storage.mode(x) <- to
+    if (to == "character") {
+      x[] <- paste(x, "number")
+    }
+    x
+  }
+
+  ## First, this is all easy and has been well tested already:
+  mod <- gen(scalar = scalar,
+             vector = vector,
+             matrix = matrix,
+             array = array,
+             array4 = array4)
+  dat <- mod$contents()
+
+  expect_equal(dat$scalar, scalar)
+  expect_equal(dat$vector, vector)
+  expect_equal(dat$matrix, matrix)
+  expect_equal(dat$array,  array)
+  expect_equal(dat$array4, array4)
+
+  ## Then to integer first:
+  mod <- gen(scalar = convert(scalar),
+             vector = convert(vector),
+             matrix = convert(matrix),
+             array = convert(array),
+             array4 = convert(array4))
+  dat <- mod$contents()
+  expect_equal(dat$scalar, scalar)
+  expect_equal(dat$vector, vector)
+  expect_equal(dat$matrix, matrix)
+  expect_equal(dat$array,  array)
+  expect_equal(dat$array4, array4)
+
+  ## Then test for errors on each as we convert to character:
+  expect_error(
+    gen(scalar = convert(scalar, "character"),
+        vector = vector,
+        matrix = matrix,
+        array = array,
+        array4 = array4),
+    "Expected a numeric value for scalar")
+  expect_error(
+    gen(scalar = scalar,
+        vector = convert(vector, "character"),
+        matrix = matrix,
+        array = array,
+        array4 = array4),
+    "Expected a numeric value for vector")
+  expect_error(
+    gen(scalar = scalar,
+        vector = vector,
+        matrix = convert(matrix, "character"),
+        array = array,
+        array4 = array4),
+    "Expected a numeric value for matrix")
+  expect_error(
+    gen(scalar = scalar,
+        vector = vector,
+        matrix = matrix,
+        array = convert(array, "character"),
+        array4 = array4),
+    "Expected a numeric value for array")
+  expect_error(
+    gen(scalar = scalar,
+        vector = vector,
+        matrix = matrix,
+        array = array,
+        array4 = convert(array4, "character")),
+    "Expected a numeric value for array4")
+})
+
+test_that("only used in output", {
+  skip("needs output")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- 1
+    r[] <- 0.1
+    dim(r) <- 3
+    dim(y) <- 3
+    ## output only:
+    tot <- sum(y)
+    output(ytot) <- tot
+    output(y2[]) <- y[i] * 2
+    dim(y2) <- length(y)
+  })
+
+  mod <- gen()
+  tt <- seq(0, 10, length.out = 101)
+  res <- mod$transform_variables(mod$run(tt))
+  expect_equal(res$ytot, rowSums(res$y))
+  expect_equal(res$y2, res$y * 2)
+})
+
+test_that("overlapping graph", {
+  skip("needs output")
+  gen <- odin_js({
+    deriv(y) <- y * p
+    initial(y) <- 1
+    r <- -0.5
+    p <- r * sqrt(t) # used in both deriv and output
+    p2 <- p * 2 # used in output only
+    output(p3) <- p + p2
+  }, verbose = FALSE)
+
+  mod <- gen()
+  tt <- seq(0, 10, length.out = 101)
+
+  f <- function(t, y, p) {
+    r <- -0.5
+    p <- r * sqrt(t)
+    p2 <- p * 2
+    list(y * p, p + p2)
+  }
+  cmp <- deSolve::ode(1, tt, f, NULL)
+  expect_equivalent(mod$run(tt), cmp)
+})
+
+test_that("sum over one dimension", {
+  skip("user arrays")
+  ## This does rowSums / colSums and will be important for building up
+  ## towards a general sum.
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 1
+
+    m[,] <- user()
+    dim(m) <- user()
+
+    v1[] <- sum(m[i, ])
+    dim(v1) <- dim(m, 1)
+    v2[] <- sum(m[, i])
+    dim(v2) <- dim(m, 2)
+
+    v3[] <- sum(m[i, 2:4])
+    dim(v3) <- length(v1)
+    v4[] <- sum(m[2:4, i])
+    dim(v4) <- length(v2)
+
+    tot1 <- sum(m)
+    tot2 <- sum(m[,])
+  })
+
+  nr <- 5
+  nc <- 7
+  m <- matrix(runif(nr * nc), nr, nc)
+  dat <- gen(m = m)$contents()
+
+  expect_equal(dat$m, m)
+  expect_equal(dat$v1, rowSums(m))
+  expect_equal(dat$v2, colSums(m))
+
+  expect_equal(dat$v3, rowSums(m[, 2:4]))
+  expect_equal(dat$v4, colSums(m[2:4, ]))
+
+  expect_equal(dat$tot1, sum(m))
+  expect_equal(dat$tot2, sum(m))
+})
+
+test_that("sum over two dimensions", {
+  skip("user arrays")
+  ## This is where things get a bit more horrid:
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 1
+
+    a[,,] <- user()
+    dim(a) <- user()
+
+    ## These collapse one dimension
+    m12[,] <- sum(a[i, j, ])
+    m13[,] <- sum(a[i, , j])
+    m23[,] <- sum(a[, i, j])
+
+    dim(m12) <- c(dim(a, 1), dim(a, 2))
+    dim(m13) <- c(dim(a, 1), dim(a, 3))
+    dim(m23) <- c(dim(a, 2), dim(a, 3))
+
+    ## These collapse two dimensions
+    v1[] <- sum(a[i, , ])
+    v2[] <- sum(a[, i, ])
+    v3[] <- sum(a[, , i])
+    dim(v1) <- dim(a, 1)
+    dim(v2) <- dim(a, 2)
+    dim(v3) <- dim(a, 3)
+
+    mm12[,] <- sum(a[i, j, 2:4])
+    mm13[,] <- sum(a[i, 2:4, j])
+    mm23[,] <- sum(a[2:4, i, j])
+    ## TODO: dim(mm12) <- dim(m12) will not work, but that would be nice
+    dim(mm12) <- c(dim(a, 1), dim(a, 2))
+    dim(mm13) <- c(dim(a, 1), dim(a, 3))
+    dim(mm23) <- c(dim(a, 2), dim(a, 3))
+
+    vv1[] <- sum(a[i, 2:4, 2:4])
+    vv2[] <- sum(a[2:4, i, 2:4])
+    vv3[] <- sum(a[2:4, 2:4, i])
+    dim(vv1) <- dim(a, 1)
+    dim(vv2) <- dim(a, 2)
+    dim(vv3) <- dim(a, 3)
+
+    tot1 <- sum(a)
+    tot2 <- sum(a[,,])
+  }, verbose = FALSE)
+
+  nr <- 5
+  nc <- 7
+  nz <- 9
+  a <- array(runif(nr * nc * nz), c(nr, nc, nz))
+  dat <- gen(a = a)$contents()
+
+  expect_equal(dat$a, a)
+  expect_equal(dat$m12, apply(a, 1:2, sum))
+  expect_equal(dat$m13, apply(a, c(1, 3), sum))
+  expect_equal(dat$m23, apply(a, 2:3, sum))
+
+  expect_equal(dat$v1, apply(a, 1, sum))
+  expect_equal(dat$v2, apply(a, 2, sum))
+  expect_equal(dat$v3, apply(a, 3, sum))
+
+  expect_equal(dat$mm12, apply(a[,,2:4], 1:2, sum))
+  expect_equal(dat$mm13, apply(a[,2:4,], c(1, 3), sum))
+  expect_equal(dat$mm23, apply(a[2:4,,], 2:3, sum))
+
+  expect_equal(dat$vv1, apply(a[,2:4,2:4], 1, sum))
+  expect_equal(dat$vv2, apply(a[2:4,,2:4], 2, sum))
+  expect_equal(dat$vv3, apply(a[2:4,2:4,], 3, sum))
+
+  expect_equal(dat$tot1, sum(a))
+  expect_equal(dat$tot2, sum(a))
+})
+
+test_that("sum for a 4d array", {
+  skip("user arrays")
+  ## I don't want to check absolutely everything here, so hopefully if
+  ## these few go OK then given the more exhaustive tests above we'll
+  ## be OK
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 1
+
+    a[,,,] <- user()
+    dim(a) <- user()
+
+    m12[,] <- sum(a[i, j, , ])
+    m23[,] <- sum(a[, i, j, ])
+    m24[,] <- sum(a[, i, , j])
+
+    dim(m12) <- c(dim(a, 1), dim(a, 2))
+    dim(m23) <- c(dim(a, 2), dim(a, 3))
+    dim(m24) <- c(dim(a, 2), dim(a, 4))
+
+    tot1 <- sum(a)
+    tot2 <- sum(a[,,,])
+  }, verbose = FALSE)
+
+  dim <- c(3, 5, 7, 9)
+  a <- array(runif(prod(dim)), dim)
+  dat <- gen(a = a)$contents()
+
+  expect_equal(dat$a, a)
+  expect_equal(dat$m12, apply(a, 1:2, sum))
+  expect_equal(dat$m23, apply(a, c(2, 3), sum))
+  expect_equal(dat$m24, apply(a, c(2, 4), sum))
+})
+
+test_that("self output for scalar", {
+  skip("output")
+  gen <- odin_js({
+    initial(a) <- 1
+    deriv(a) <- 0
+    x <- t
+    output(x) <- TRUE
+  })
+
+  tt <- seq(0, 10, length.out = 11)
+  expect_equal(gen()$run(tt)[, "x"], tt)
+})
+
+test_that("non-time sentsitive output", {
+  skip("output")
+  gen <- odin_js({
+    initial(a) <- 1
+    deriv(a) <- 0
+    x <- 1
+    output(x) <- TRUE
+  })
+
+  tt <- seq(0, 10, length.out = 11)
+  expect_equal(gen()$run(tt)[, "x"], rep(1, length(tt)))
+})
+
+test_that("logical operations", {
+  skip("output")
+  gen <- odin_js({
+    initial(a) <- 1
+    deriv(a) <- 0
+
+    ## These ones are easy
+    output(x1) <- t > 1 && t < 3
+    output(x2) <- t > 1 || t < 3
+
+    ## These ones may differ; note that parens are suggested by the
+    ## compiler for this line.
+    output(x3) <- t > 8 || t > 1 && t < 3 # should equal x4
+    output(x4) <- t > 8 || (t > 1 && t < 3)
+    output(x5) <- (t > 8 || t > 1) && t < 3
+  }, compiler_warnings = FALSE)
+
+  t <- seq(0, 10, length.out = 101)
+  y <- gen()$run(t)
+
+  expect_equal(y[, "x1"], as.numeric(t > 1 & t < 3))
+  expect_equal(y[, "x2"], as.numeric(t > 1 | t < 3))
+  expect_equal(y[, "x3"], as.numeric(t > 8 | t > 1 & t < 3))
+  expect_equal(y[, "x4"], as.numeric(t > 8 | (t > 1 & t < 3)))
+  expect_equal(y[, "x5"], as.numeric((t > 8 | t > 1) & t < 3))
+})
+
+## This is for issue #44, needed to support Neil's model.  I don't
+## know how useful this is going to be.  I'll see if we can get away
+## with this for now, and then go through and see if we can detect if
+## a number is an integer thing because it's only used within indexes.
+test_that("integer vector", {
+  skip("user dimensions")
+  ## We expect 'idx' to come through as an integer
+  gen <- odin_js({
+    x[] <- user()
+    dim(x) <- user()
+    idx[] <- user()
+    dim(idx) <- user()
+    initial(v[]) <- x[idx[i]] # TODO: fixme
+    deriv(v[]) <- 0
+    dim(v) <- length(x)
+  })
+
+  set.seed(1)
+  idx <- sample(15)
+  x <- runif(length(idx))
+  mod <- gen(x = x, idx = idx)
+  dat <- mod$contents()
+  expect_equal(dat$idx, idx)
+  expect_equal(dat$initial_v, x[idx])
+
+  expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
+               "int")
+})
+
+## This is much closer to the test case needed for Neil's model
+test_that("integer matrix", {
+  skip("user dimensions")
+  gen <- odin_js({
+    x[] <- user()
+    dim(x) <- user()
+
+    idx[, ] <- user()
+    dim(idx) <- c(length(x), 3)
+
+    v[] <- x[idx[i, 1]] + x[idx[i, 2]] + x[idx[i, 3]]
+    dim(v) <- length(x)
+
+    initial(z) <- 1
+    deriv(z) <- 0
+  })
+
+  x <- runif(10)
+  idx <- matrix(sample(length(x), length(x) * 3, replace = TRUE), length(x), 3)
+  ## This is what the code should expand to:
+  v <- x[idx[, 1]] + x[idx[, 2]] + x[idx[, 3]]
+
+  mod <- gen(x = x, idx = idx)
+  expect_equal(mod$contents()$v, v)
+  expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
+               "int")
+})
+
+test_that("c in dim for vector", {
+  ## This is a regression test for issue #61
+  gen <- odin_js({
+    initial(x[]) <- 1
+    deriv(x[]) <- 0
+    dim(x) <- c(5)
+  })
+  mod <- gen()
+  expect_equal(mod$contents()$initial_x, rep(1.0, 5))
+})
+
+
+test_that("user variable information", {
+  skip("user arrays")
+  gen <- odin_js({
+    deriv(N) <- r[1] * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- user(1)
+    K <- user(100)
+    r[] <- user()
+    dim(r) <- 1
+  })
+
+  info <- coef(gen)
+  expect_is(info, "data.frame")
+  expect_equal(info$name, names(formals(gen))[1:3])
+  expect_equal(info$has_default, c(FALSE, TRUE, TRUE))
+  expect_equal(info$rank, c(1L, 0L, 0L))
+
+  expect_identical(coef(gen(1)), info)
+})
+
+
+test_that("user variable information - when no user", {
+  skip("user arrays")
+  gen <- odin_js({
+    deriv(N) <- r * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- 10
+    K <- 100
+    r <- 0.1
+  })
+  info <- coef(gen)
+  cmp <- data.frame(name = character(),
+                    has_default = logical(),
+                    default_value = I(list()),
+                    rank = integer(),
+                    min = numeric(),
+                    max = numeric(),
+                    integer = logical(),
+                    stringsAsFactors = FALSE)
+  expect_identical(info, cmp)
+  expect_identical(coef(gen()), cmp)
+})
+
+
+test_that("format/print", {
+  skip("user arrays")
+  gen <- odin_js({
+    deriv(N) <- r[1] * N * (1 - N / K)
+    initial(N) <- N0
+    N0 <- user(1)
+    K <- user(100)
+    r[] <- user()
+    dim(r) <- 1
+  })
+
+  txt <- capture.output(x <- withVisible(print(gen)))
+  expect_match(txt,
+               capture.output(args(gen))[[1]],
+               fixed = TRUE, all = FALSE)
+  expect_match(txt,
+               "<an 'odin_generator' function>",
+               fixed = TRUE, all = FALSE)
+  expect_match(txt,
+               "use coef() to get information on user parameters",
+               fixed = TRUE, all = FALSE)
+
+  expect_identical(x, list(value = gen, visible = FALSE))
+})
+
+
+test_that("ir is read-only", {
+  gen <- odin_js({
+    deriv(y) <- 0.5
+    initial(y) <- 1
+  })
+  mod <- gen()
+  ir <- mod$ir
+  expect_error(mod$ir <- TRUE)
+  expect_identical(mod$ir, ir)
+})
+
+
+test_that("multiline string", {
+  ## Literal multiline string:
+  gen <- odin_js(c("deriv(y) <- 0.5", "initial(y) <- 1"))
+  expect_is(gen(), "odin_model")
+})
+
+
+## This is basically all ok but what is still not great is _doing_ the
+## validation.
+test_that("user integer", {
+  skip("user integer support")
+  gen <- odin_js({
+    deriv(y) <- 0.5
+    initial(y) <- y0
+    y0 <- user(1, integer = TRUE, min = 0)
+  })
+
+  expect_error(gen(y0 = 1.5), "Expected 'y0' to be integer-like")
+  expect_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
+
+  expect_error(mod <- gen(y0 = 1), NA)
+  expect_equal(mod$run(0:10)[, "y"], 1.0 + 0.5 * (0:10))
+})
+
+
+test_that("multiple constraints", {
+  skip("user constraints")
+  gen <- odin_js({
+    deriv(y) <- r
+    initial(y) <- y0
+    y0 <- user(1, min = 0)
+    r <- user(0.5, max = 10)
+  })
+
+  expect_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
+  expect_error(gen(r = 100), "Expected 'r' to be at most 10")
+})
+
+
+test_that("set_user honours constraints", {
+  skip("user constraints")
+  gen <- odin_js({
+    deriv(y) <- r
+    initial(y) <- y0
+    y0 <- user(1, min = 0)
+    r <- user(0.5, max = 10)
+  })
+
+  mod <- gen()
+  expect_error(mod$set_user(y0 = -1L), "Expected 'y0' to be at least 0")
+  expect_error(mod$set_user(r = 100), "Expected 'r' to be at most 10")
+})
+
+
+test_that("user sized dependent variables are allowed", {
+  skip("user arrays")
+  gen <- odin_js({
+    deriv(y[]) <- r[i] * y[i]
+    initial(y[]) <- 1
+    r[] <- user()
+    dim(r) <- user()
+    dim(y) <- length(r)
+  })
+  r <- runif(3)
+  mod <- gen(r = r)
+  expect_identical(mod$contents()$r, r)
+  expect_identical(mod$contents()$initial_y, rep(1.0, length(r)))
+})
+
+
+test_that("user parameter validation", {
+  skip("user validation")
+  gen <- odin_js({
+    deriv(y) <- r
+    initial(y) <- 1
+    r <- user()
+  })
+
+  ## Honour all the options:
+  expect_error(
+    gen(user = list(r = 1, a = 1), unused_user_action = "stop"),
+    "Unknown user parameters: a")
+  expect_warning(
+    gen(user = list(r = 1, a = 1), unused_user_action = "warning"),
+    "Unknown user parameters: a")
+  expect_message(
+    gen(user = list(r = 1, a = 1), unused_user_action = "message"),
+    "Unknown user parameters: a")
+  expect_silent(
+    gen(user = list(r = 1, a = 1), unused_user_action = "ignore"))
+
+  ## Sensible error message for invalid option
+  expect_error(
+    gen(user = list(r = 1, a = 1), unused_user_action = "other"),
+    "Unknown user parameters: a (and invalid value for unused_user_action)",
+    fixed = TRUE)
+
+  ## Inherit action from option
+  with_options(
+    list(odin.unused_user_action = "message"),
+    expect_message(
+      gen(user = list(r = 1, a = 1)),
+      "Unknown user parameters: a"))
+
+  ## Override option
+  with_options(
+    list(odin.unused_user_action = "message"),
+    expect_error(
+      gen(user = list(r = 1, a = 1), unused_user_action = "error"),
+      "Unknown user parameters: a"))
+
+  ## System default:
+  with_options(
+    list(odin.unused_user_action = NULL),
+    expect_warning(
+      gen(user = list(r = 1, a = 1)),
+      "Unknown user parameters: a"))
+
+  ## set_user:
+  mod <- gen(r = 1)
+  expect_silent(
+    mod$set_user(user = list(x = 1), unused_user_action = "ignore"))
+  expect_error(
+    mod$set_user(user = list(x = 1), unused_user_action = "error"),
+    "Unknown user parameters: x")
 })

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -57,7 +57,7 @@ test_that("user variables", {
 })
 
 test_that("user variables on models with none", {
-  skip("needs work")
+  skip("interface issue")
   gen <- odin_js({
     a <- 1
     deriv(y) <- 0.5 * a
@@ -120,7 +120,7 @@ test_that("delays and initial conditions", {
 })
 
 test_that("non-numeric user", {
-  skip("needs work")
+  skip("interface issue")
   gen <- odin_js({
     deriv(N) <- r * N * (1 - N / K)
     initial(N) <- N0
@@ -217,7 +217,7 @@ test_that("time dependent initial conditions", {
 })
 
 test_that("user c", {
-  skip("never going to use this")
+  skip("not relevant")
   skip_for_target("r")
   gen <- odin_js({
     config(include) <- "user_fns.c"
@@ -239,7 +239,7 @@ test_that("user c", {
 })
 
 test_that("user c in subdir", {
-  skip("never going to use this")
+  skip("not relevant")
   skip_for_target("r")
   dest <- tempfile()
   dir.create(dest)
@@ -665,10 +665,7 @@ test_that("two output arrays", {
   expect_equal(res, yy)
 })
 
-## TODO: This still needs harmonising with get_user_array1 functions
-## (non user dimensions) as they use coerceVector still.
 test_that("non-numeric input", {
-  skip("needs user dimension support")
   gen <- odin_js({
     deriv(y) <- 1
     initial(y) <- 1
@@ -707,9 +704,10 @@ test_that("non-numeric input", {
 
   expect_equal(dat$scalar, scalar)
   expect_equal(dat$vector, vector)
-  expect_equal(dat$matrix, matrix)
-  expect_equal(dat$array,  array)
-  expect_equal(dat$array4, array4)
+  ## TODO: should shape these back on return
+  expect_equal(dat$matrix, c(matrix))
+  expect_equal(dat$array,  c(array))
+  expect_equal(dat$array4, c(array4))
 
   ## Then to integer first:
   mod <- gen(scalar = convert(scalar),
@@ -720,9 +718,10 @@ test_that("non-numeric input", {
   dat <- mod$contents()
   expect_equal(dat$scalar, scalar)
   expect_equal(dat$vector, vector)
-  expect_equal(dat$matrix, matrix)
-  expect_equal(dat$array,  array)
-  expect_equal(dat$array4, array4)
+  ## TODO: should shape these back on return
+  expect_equal(dat$matrix, c(matrix))
+  expect_equal(dat$array,  c(array))
+  expect_equal(dat$array4, c(array4))
 
   ## Then test for errors on each as we convert to character:
   expect_error(
@@ -731,35 +730,40 @@ test_that("non-numeric input", {
         matrix = matrix,
         array = array,
         array4 = array4),
-    "Expected a numeric value for scalar")
+    "Expected a numeric value for 'scalar'",
+    class = "std::runtime_error")
   expect_error(
     gen(scalar = scalar,
         vector = convert(vector, "character"),
         matrix = matrix,
         array = array,
         array4 = array4),
-    "Expected a numeric value for vector")
+    "Expected a numeric value for 'vector'",
+    class = "std::runtime_error")
   expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = convert(matrix, "character"),
         array = array,
         array4 = array4),
-    "Expected a numeric value for matrix")
+    "Expected a numeric value for 'matrix'",
+    class = "std::runtime_error")
   expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = matrix,
         array = convert(array, "character"),
         array4 = array4),
-    "Expected a numeric value for array")
+    "Expected a numeric value for 'array'",
+    class = "std::runtime_error")
   expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = matrix,
         array = array,
         array4 = convert(array4, "character")),
-    "Expected a numeric value for array4")
+    "Expected a numeric value for 'array4'",
+    class = "std::runtime_error")
 })
 
 test_that("only used in output", {
@@ -809,7 +813,7 @@ test_that("overlapping graph", {
 })
 
 test_that("sum over one dimension", {
-  skip("user arrays")
+  skip("sum")
   ## This does rowSums / colSums and will be important for building up
   ## towards a general sum.
   gen <- odin_js({
@@ -850,7 +854,7 @@ test_that("sum over one dimension", {
 })
 
 test_that("sum over two dimensions", {
-  skip("user arrays")
+  skip("sum")
   ## This is where things get a bit more horrid:
   gen <- odin_js({
     deriv(y) <- 0
@@ -923,7 +927,7 @@ test_that("sum over two dimensions", {
 })
 
 test_that("sum for a 4d array", {
-  skip("user arrays")
+  skip("sum")
   ## I don't want to check absolutely everything here, so hopefully if
   ## these few go OK then given the more exhaustive tests above we'll
   ## be OK
@@ -957,7 +961,7 @@ test_that("sum for a 4d array", {
 })
 
 test_that("self output for scalar", {
-  skip("output")
+  skip("needs output")
   gen <- odin_js({
     initial(a) <- 1
     deriv(a) <- 0
@@ -970,7 +974,7 @@ test_that("self output for scalar", {
 })
 
 test_that("non-time sentsitive output", {
-  skip("output")
+  skip("needs output")
   gen <- odin_js({
     initial(a) <- 1
     deriv(a) <- 0
@@ -983,7 +987,7 @@ test_that("non-time sentsitive output", {
 })
 
 test_that("logical operations", {
-  skip("output")
+  skip("needs output")
   gen <- odin_js({
     initial(a) <- 1
     deriv(a) <- 0
@@ -1014,7 +1018,6 @@ test_that("logical operations", {
 ## with this for now, and then go through and see if we can detect if
 ## a number is an integer thing because it's only used within indexes.
 test_that("integer vector", {
-  skip("user dimensions")
   ## We expect 'idx' to come through as an integer
   gen <- odin_js({
     x[] <- user()
@@ -1034,13 +1037,13 @@ test_that("integer vector", {
   expect_equal(dat$idx, idx)
   expect_equal(dat$initial_v, x[idx])
 
+  skip("interface issue")
   expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
                "int")
 })
 
 ## This is much closer to the test case needed for Neil's model
 test_that("integer matrix", {
-  skip("user dimensions")
   gen <- odin_js({
     x[] <- user()
     dim(x) <- user()
@@ -1062,6 +1065,8 @@ test_that("integer matrix", {
 
   mod <- gen(x = x, idx = idx)
   expect_equal(mod$contents()$v, v)
+
+  skip("interface issue")
   expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
                "int")
 })
@@ -1090,7 +1095,7 @@ test_that("user variable information", {
 
   info <- coef(gen)
   expect_is(info, "data.frame")
-  expect_equal(info$name, names(formals(gen))[1:3])
+  ## expect_equal(info$name, names(formals(gen))[1:3])
   expect_equal(info$has_default, c(FALSE, TRUE, TRUE))
   expect_equal(info$rank, c(1L, 0L, 0L))
 
@@ -1195,8 +1200,8 @@ test_that("multiple constraints", {
     r <- user(0.5, max = 10)
   })
 
-  expect_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
-  expect_error(gen(r = 100), "Expected 'r' to be at most 10")
+  expect_js_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
+  expect_js_error(gen(r = 100), "Expected 'r' to be at most 10")
 })
 
 
@@ -1209,13 +1214,13 @@ test_that("set_user honours constraints", {
   })
 
   mod <- gen()
-  expect_error(mod$set_user(list(y0 = -1L)), "Expected 'y0' to be at least 0")
-  expect_error(mod$set_user(list(r = 100)), "Expected 'r' to be at most 10")
+  expect_js_error(mod$set_user(list(y0 = -1L)),
+                  "Expected 'y0' to be at least 0")
+  expect_js_error(mod$set_user(list(r = 100)), "Expected 'r' to be at most 10")
 })
 
 
 test_that("user sized dependent variables are allowed", {
-  skip("user arrays")
   gen <- odin_js({
     deriv(y[]) <- r[i] * y[i]
     initial(y[]) <- 1
@@ -1225,8 +1230,8 @@ test_that("user sized dependent variables are allowed", {
   })
   r <- runif(3)
   mod <- gen(r = r)
-  expect_identical(mod$contents()$r, r)
-  expect_identical(mod$contents()$initial_y, rep(1.0, length(r)))
+  expect_equal(mod$contents()$r, r)
+  expect_equal(mod$contents()$initial_y, rep(1.0, length(r)))
 })
 
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -813,7 +813,6 @@ test_that("overlapping graph", {
 })
 
 test_that("sum over one dimension", {
-  skip("sum")
   ## This does rowSums / colSums and will be important for building up
   ## towards a general sum.
   gen <- odin_js({
@@ -842,7 +841,7 @@ test_that("sum over one dimension", {
   m <- matrix(runif(nr * nc), nr, nc)
   dat <- gen(m = m)$contents()
 
-  expect_equal(dat$m, m)
+  expect_equal(dat$m, c(m)) # TODO: reshape
   expect_equal(dat$v1, rowSums(m))
   expect_equal(dat$v2, colSums(m))
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1184,7 +1184,7 @@ test_that("user integer", {
                "Expected 'y0' to be at least 0",
                class = "std::runtime_error")
 
-  expect_error(mod <- gen(y0 = 1), NA)
+  mod <- gen(y0 = 1)
   expect_equal(mod$run(0:10)[, "y"], 1.0 + 0.5 * (0:10))
 })
 

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -1,0 +1,7 @@
+context("support")
+
+test_that("isMissing", {
+  ctx <- odin_js_support()
+  expect_false(ctx$call("isMissing", 1))
+  expect_true(ctx$call("isMissing", V8::JS("null")))
+})

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -8,6 +8,13 @@ test_that("isMissing", {
 })
 
 
+test_that("numberIsInteger", {
+  ctx <- odin_js_support()
+  expect_true(ctx$call("numberIsInteger", 1))
+  expect_false(ctx$call("numberIsInteger", 1.5))
+})
+
+
 test_that("getUserArray", {
   ctx <- odin_js_support()
   helper <- c(

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -8,6 +8,77 @@ test_that("isMissing", {
 })
 
 
+test_that("getUserArray", {
+  ctx <- odin_js_support()
+  helper <- c(
+    "function test(user, name, size, defaultValue, min, max, isInteger) {",
+    "  var internal = {};",
+    "  getUserArray(user, name, internal, size, defaultValue, min, max,",
+    "               isInteger);",
+    "  return internal[name];",
+    "}")
+
+  ctx$eval(helper)
+
+  ## Get the required user data:
+  user <- list(a = jsonlite::unbox(1),
+               b = list(data = 1:6, dim = 2:3),
+               c = list(data = 1:4, dim = I(4)))
+  dim_b <- c(6, 2, 3)
+  dim_c <- c(4, 4)
+  dim_3 <- c(6, 2, 3, 1)
+
+  null <- V8::JS("null")
+  expect_equal(ctx$call("test", user, "b", dim_b, null, null, null, FALSE),
+               1:6)
+  expect_equal(ctx$call("test", user, "c", dim_c, null, null, null, FALSE),
+               1:4)
+
+  ## Check exists
+  expect_error(
+    ctx$call("test", user, "x", dim_b, null, null, null, FALSE),
+    "Expected a value for 'x'",
+    class = "std::runtime_error")
+
+  ## Throw if not a matrix-type object
+  expect_error(
+    ctx$call("test", user, "a", dim_b, null, null, null, FALSE),
+    "Expected an odin.js array object",
+    class = "std::runtime_error")
+
+  ## Check ranks
+  expect_error(
+    ctx$call("test", user, "b", dim_3, null, null, null, FALSE),
+    "Expected a numeric array of rank 3 for 'b'",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "b", dim_c, null, null, null, FALSE),
+    "Expected a numeric vector for 'b'",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "c", dim_b, null, null, null, FALSE),
+    "Expected a numeric matrix for 'c'",
+    class = "std::runtime_error")
+
+  ## Check is a number
+  user$b$data <- letters[1:6]
+  expect_error(
+    ctx$call("test", user, "b", dim_b, null, null, null, FALSE),
+    "Expected a number for 'b'",
+    class = "std::runtime_error")
+
+  ## Check range
+  expect_error(
+    ctx$call("test", user, "c", dim_c, null, 3, null, FALSE),
+    "Expected 'c' to be at least 3",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "c", dim_c, null, null, 3, FALSE),
+    "Expected 'c' to be at most 3",
+    class = "std::runtime_error")
+})
+
+
 test_that("getUserArrayDim", {
   ctx <- odin_js_support()
   helper <- c(

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -145,3 +145,10 @@ test_that("getUserArrayDim", {
     "Expected 'c' to be at most 3",
     class = "std::runtime_error")
 })
+
+
+test_that("generate sum", {
+  code <- unlist(lapply(2:8, generate_js_support_sum))
+  expect_equal(code,
+               readLines(system.file("support_sum.js", package = "odin.js")))
+})

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -3,5 +3,6 @@ context("support")
 test_that("isMissing", {
   ctx <- odin_js_support()
   expect_false(ctx$call("isMissing", 1))
+  expect_false(ctx$call("isMissing", list(a = 1, b = 2)))
   expect_true(ctx$call("isMissing", V8::JS("null")))
 })

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -64,7 +64,7 @@ test_that("getUserArray", {
   user$b$data <- letters[1:6]
   expect_error(
     ctx$call("test", user, "b", dim_b, null, null, null, FALSE),
-    "Expected a number for 'b'",
+    "Expected a numeric value for 'b'",
     class = "std::runtime_error")
 
   ## Check range
@@ -132,7 +132,7 @@ test_that("getUserArrayDim", {
   user$b$data <- letters[1:6]
   expect_error(
     ctx$call("test", user, "b", 2, null, null, null, FALSE),
-    "Expected a number for 'b'",
+    "Expected a numeric value for 'b'",
     class = "std::runtime_error")
 
   ## Check range

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -6,3 +6,71 @@ test_that("isMissing", {
   expect_false(ctx$call("isMissing", list(a = 1, b = 2)))
   expect_true(ctx$call("isMissing", V8::JS("null")))
 })
+
+
+test_that("getUserArrayDim", {
+  ctx <- odin_js_support()
+  helper <- c(
+    "function test(user, name, rank, defaultValue, min, max, isInteger) {",
+    "  var internal = {};",
+    "  var size = new Array(rank + 1);",
+    "  getUserArrayDim(user, name, internal, size, defaultValue, min, max,",
+    "                  isInteger);",
+    "  return {value: internal[name], size: size};",
+    "}")
+
+  ctx$eval(helper)
+
+  ## Get the required user data:
+  user <- list(a = jsonlite::unbox(1),
+               b = list(data = 1:6, dim = 2:3),
+               c = list(data = 1:6, dim = I(6)))
+  null <- V8::JS("null")
+  expect_equal(ctx$call("test", user, "b", 2, null, null, null, FALSE),
+               list(value = 1:6, size = c(6, 2, 3)))
+  expect_equal(ctx$call("test", user, "c", 1, null, null, null, FALSE),
+               list(value = 1:6, size = c(6, 6)))
+
+  ## Check exists
+  expect_error(
+    ctx$call("test", user, "x", 2, null, null, null, FALSE),
+    "Expected a value for 'x'",
+    class = "std::runtime_error")
+
+  ## Throw if not a matrix-type object
+  expect_error(
+    ctx$call("test", user, "a", 2, null, null, null, FALSE),
+    "Expected an odin.js array object",
+    class = "std::runtime_error")
+
+  ## Check ranks
+  expect_error(
+    ctx$call("test", user, "b", 3, null, null, null, FALSE),
+    "Expected a numeric array of rank 3 for 'b'",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "b", 1, null, null, null, FALSE),
+    "Expected a numeric vector for 'b'",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "c", 2, null, null, null, FALSE),
+    "Expected a numeric matrix for 'c'",
+    class = "std::runtime_error")
+
+  ## Check is a number
+  user$b$data <- letters[1:6]
+  expect_error(
+    ctx$call("test", user, "b", 2, null, null, null, FALSE),
+    "Expected a number for 'b'",
+    class = "std::runtime_error")
+
+  ## Check range
+  expect_error(
+    ctx$call("test", user, "c", 1, null, 3, null, FALSE),
+    "Expected 'c' to be at least 3",
+    class = "std::runtime_error")
+  expect_error(
+    ctx$call("test", user, "c", 1, null, null, 3, FALSE),
+    "Expected 'c' to be at most 3",
+    class = "std::runtime_error")
+})


### PR DESCRIPTION
This PR adds basic support for arrays.  Arrays can be used for variables as well as intermediate values, and can be provided by users, including where the size is inferred from the provided value.

This PR is pretty big, but most of it is just importing (with minor modifications) chunks of the odin test suite.  Eventually we'll probably roll this back into odin itself to reduce the duplication there.

There's quite a few interface nasties to go, but these are not needed for the current work so I have just commented them out or skipped them.  I am also not completely convinced that `setUser()` will do the right thing so please avoid that at the moment.

One complication is for arrays.  Rather than accept nested-arrays (which get hard to work with within the solver) I have gone with an R-ish approach of passing in a dict:

```js
{data: [1, 2, 3, 4, 5, 6], dim: [2, 3]}
```

which corresponds to the R matrix:

```r
matrix(1:6, 2:3)
```

i.e., column major. We can tidy that up later if we need to too.

---

There's a bit to go here, not sure if it will all come in the first PR (so keeping this draft for now):

* ~arrays with more than one dimension~
* ~user provided arrays~
* ~sum over arrays or partial arrays~