### PR TITLE
mrc-1493: support output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.3
+Version: 0.1.4
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,16 +8,17 @@ Authors@R:
            email = "rich.fitzjohn@gmail.com")
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
-Description: Create 'JavaScript' differential equation models from an 'odin' model specification.
+Description: Create 'JavaScript' differential equation models from an
+    'odin' model specification.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-  R6 (>= 2.4.0),
-  V8,
-  jsonlite,
-  odin (>= 0.2.0)
+    R6 (>= 2.4.0),
+    V8,
+    jsonlite,
+    odin (>= 0.2.0)
 Suggests:
-  deSolve,
-  testthat
+    deSolve,
+    testthat
 RoxygenNote: 6.1.1

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -256,7 +256,9 @@ generate_js_generator <- function(core, dat) {
   body$add(core$create)
   body$add(method("setUser", core$set_user))
   body$add(method("rhs", core$rhs))
-  body$add(method("output", core$output))
+  if (!is.null(core$output)) {
+    body$add(method("output", core$output))
+  }
   body$add(method("rhsEval", core$rhs_eval))
   body$add(method("initial", core$initial_conditions))
   body$add(method("run", core$run))

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -87,7 +87,7 @@ generate_js_core_output <- function(eqs, dat, rewrite) {
 
   internal <- sprintf("var %s = this.%s;", dat$meta$internal, dat$meta$internal)
   alloc <- sprintf("var %s = new Array(%s);",
-                   dat$meta$output, rewrite(dat$data$variable$length))
+                   dat$meta$output, rewrite(dat$data$output$length))
   unpack <- lapply(variables, js_unpack_variable, dat, dat$meta$state, rewrite)
   ret <- sprintf("return %s;", dat$meta$output)
   body <- js_flatten_eqs(c(internal, alloc, unpack, eqs[equations], ret))

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -11,7 +11,7 @@ generate_js_equation <- function(eq, dat, rewrite) {
     alloc = generate_js_equation_alloc,
     copy = generate_js_equation_copy,
     user = generate_js_equation_user,
-    stop(sprintf("Unknown type '%s' [odin.js bug]")))
+    stop(sprintf("Unknown type '%s' [odin.js bug]", eq$type)))
 
   data_info <- dat$data$elements[[eq$lhs]]
   stopifnot(!is.null(data_info))

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -69,7 +69,14 @@ R6_odin_js_wrapper <- R6::R6Class(
       ## TODO: check length of 'y' here?
       t_js <- to_json(scalar(t))
       y_js <- to_json(y, auto_unbox = FALSE)
-      private$context$call(sprintf("%s.rhsEval", private$name), t_js, y_js)
+      ret <- private$context$call(sprintf("%s.rhsEval", private$name),
+                                  t_js, y_js)
+      ## This is super ugly but should do the trick for now:
+      if (length(ret) > length(y)) {
+        i <- seq_along(y)
+        ret <- structure(ret[i], output = ret[-i])
+      }
+      ret
     },
 
     contents = function() {

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,8 +60,8 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 ### Supported features
 
 - [x] user variables
-- [ ] output
-- [ ] arrays
+- [x] output
+- [x] arrays
 - [ ] delays
 - [ ] interpolation
 - [ ] discrete models

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 ### Supported features
 
 - [x] user variables
-- [ ] output
-- [ ] arrays
+- [x] output
+- [x] arrays
 - [ ] delays
 - [ ] interpolation
 - [ ] discrete models

--- a/inst/support.js
+++ b/inst/support.js
@@ -16,7 +16,15 @@ function integrateOdin(obj, times, y0) {
     var rhs = function(t, y, dy) {
         obj.rhs(t, y, dy);
     };
-    var sol = dopri.integrate(rhs, y0, t0, t1);
+    var sol = null;
+    if (obj.output === null) {
+        sol = dopri.integrate(rhs, y0, t0, t1, {});
+    } else {
+        var output = function(t, y) {
+            return obj.output(t, y);
+        }
+        sol = dopri.integrate(rhs, y0, t0, t1, {}, output);
+    }
     var y = sol(times);
     // Prepend the result vector with the times; this is going to be
     // required later on - it would be nice if dopri did this through

--- a/inst/support.js
+++ b/inst/support.js
@@ -17,13 +17,13 @@ function integrateOdin(obj, times, y0) {
         obj.rhs(t, y, dy);
     };
     var sol = null;
-    if (obj.output === null) {
-        sol = dopri.integrate(rhs, y0, t0, t1, {});
-    } else {
+    if (typeof obj.output === "function") {
         var output = function(t, y) {
             return obj.output(t, y);
         }
         sol = dopri.integrate(rhs, y0, t0, t1, {}, output);
+    } else {
+        sol = dopri.integrate(rhs, y0, t0, t1, {});
     }
     var y = sol(times);
     // Prepend the result vector with the times; this is going to be

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "dopri": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.2.tgz",
-            "integrity": "sha512-irCzXlys0PujtiKwLvrPg3pLSQH0sUCbY4ozDOrHhKFkyVtf4wygXkCrfWbx/ZGoypVTKZ3dkgPnDaEYLkav8Q=="
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.5.tgz",
+            "integrity": "sha512-Vvi5v1LuCf7o7VKJxy1edAZ/HlJLgAzsvp7s69cYDRqjFOJ+JFfPaTrH+DnhK5Easb2CQIMIzQ3M8tgP1iyDhg=="
         }
     }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -17,8 +17,7 @@
         "url": "https://github.com/mrc-ide/odin.js/issues"
     },
     "dependencies": {
-        "dopri": "^0.0.2",
-        "uglify-js": "^3.5.3"
+        "dopri": "^0.0.5"
     },
     "homepage": "https://github.com/mrc-ide/odin.js#readme"
 }

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -131,18 +131,6 @@ test_that("delay models are not supported", {
 })
 
 
-test_that("output is not supported", {
-  expect_error(
-    odin_js({
-      y1 <- sin(t)
-      deriv(y2) <- y1
-      initial(y2) <- -1
-      output(y1) <- y1
-    }),
-    "Using unsupported features: 'has_output'")
-})
-
-
 test_that("interpolation is not supported", {
   expect_error(
     odin_js({

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -153,7 +153,6 @@ test_that("user variables", {
 ##
 ## This one is about as basic as I can see!
 test_that("output", {
-  skip("Needs implementing")
   gen <- odin_js({
     deriv(y) <- 2
     initial(y) <- 1
@@ -172,18 +171,11 @@ test_that("output", {
   expect_equal(yy1[, "t"], tt)
   expect_equal(yy1[, "y"], seq(1, length.out = length(tt), by = 2))
   expect_equal(yy1[, "z"], tt)
-
-  yy2 <- gen(TRUE)$run(tt)
-  expect_equal(colnames(yy2), c("t", "y", "z"))
-  expect_equal(yy2[, "t"], tt)
-  expect_equal(yy2[, "y"], seq(1, length.out = length(tt), by = 2))
-  expect_equal(yy2[, "z"], tt)
 })
 
 
 ## Do some nontrivial calculation in the output
 test_that("output", {
-  skip("needs implementing")
   gen <- odin_js({
     deriv(y) <- 2
     initial(y) <- 1

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -190,7 +190,6 @@ test_that("output", {
 
 
 test_that("copy output", {
-  skip("needs implementing")
   gen <- odin_js({
     deriv(y) <- 1
     initial(y) <- 1
@@ -202,9 +201,9 @@ test_that("copy output", {
   mod <- gen()
   tt <- 0:10
   y <- mod$run(tt)
-  yy <- mod$transform_variables(y)
-  expect_equal(yy$y, tt + 1)
-  expect_equal(yy$z, matrix(tt, length(tt), 5))
+  ## yy <- mod$transform_variables(y) # TODO
+  expect_equivalent(y[, 2], tt + 1)
+  expect_equivalent(y[, 3:7], matrix(tt, length(tt), 5))
 })
 
 


### PR DESCRIPTION
This PR adds support for output (computed quantities in addition to the derivatives) for ODE models.  Both scalar and array outputs are supported and the names are handled much the same way as in odin.  To support this I had to upgrade dopri.js, which was still at a pretty old version (and in the meantime realised I'd managed to push a completely empty version to npm earlier 🙈)