### PR TITLE
mrc-1496: Add support for discrete-time and stochastic models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ r_packages:
   - covr
 addons:
   apt:
-    packages:
-      - libv8-dev
+    packages: libnode-dev
 r_github_packages:
   - mrc-ide/cinterpolate
   - ropensci/jsonvalidate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.5
+Version: 0.1.6
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -7,7 +7,7 @@ generate_js <- function(ir, options) {
 
   features <- vlapply(dat$features, identity)
   supported <- c("initial_time_dependent", "has_array", "has_user",
-                 "has_output", "has_interpolate", "discrete")
+                 "has_output", "has_interpolate", "discrete", "has_stochastic")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {
     stop("Using unsupported features: ",
@@ -26,6 +26,7 @@ generate_js <- function(ir, options) {
        name = dat$config$base,
        discrete = dat$features$discrete,
        include = c(interpolate.js = dat$features$has_interpolate,
+                   random.js = dat$stochastic,
                    support_sum.js = uses_sum))
 }
 

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -24,6 +24,7 @@ generate_js <- function(ir, options) {
   ## This is all we need to dump out
   list(code = generate_js_generator(core, dat),
        name = dat$config$base,
+       discrete = dat$features$discrete,
        include = c(interpolate.js = dat$features$has_interpolate,
                    support_sum.js = uses_sum))
 }

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -26,7 +26,8 @@ generate_js <- function(ir, options) {
        name = dat$config$base,
        discrete = dat$features$discrete,
        include = c(interpolate.js = dat$features$has_interpolate,
-                   random.js = dat$stochastic,
+                   random.js = dat$features$has_stochastic,
+                   discrete.js = dat$features$discrete,
                    support_sum.js = uses_sum))
 }
 

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -7,7 +7,7 @@ generate_js <- function(ir, options) {
 
   features <- vlapply(dat$features, identity)
   supported <- c("initial_time_dependent", "has_array", "has_user",
-                 "has_output", "has_interpolate")
+                 "has_output", "has_interpolate", "discrete")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {
     stop("Using unsupported features: ",
@@ -126,8 +126,14 @@ generate_js_core_output <- function(eqs, dat, rewrite) {
 
 
 generate_js_core_run <- function(eqs, dat, rewrite) {
-  args <- c("times", "y0", "tcrit")
-  body <- "return integrateOdin(this, times, y0, tcrit);"
+  if (dat$features$discrete) {
+    args <- c("times", "y0")
+    body <- sprintf("return iterateOdin(this, times, y0, %s);",
+                    rewrite(dat$data$output$length))
+  } else {
+    args <- c("times", "y0", "tcrit")
+    body <- "return integrateOdin(this, times, y0, tcrit);"
+  }
   js_function(args, body)
 }
 

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -28,9 +28,15 @@ generate_js_sexp <- function(x, data, meta) {
       ret <- generate_js_sexp(dim, data, meta)
     } else if (fn == "sum" || fn == "odin_sum") {
       ret <- generate_js_sexp_sum(args, data, meta)
+    } else if (any(names(FUNCTIONS_STOCHASTIC) == fn)) {
+      ret <- sprintf("random.%s(%s)()",
+                     FUNCTIONS_STOCHASTIC_SPECIAL[[fn]],
+                     paste(values, collapse = ", "))
     } else {
       if (any(FUNCTIONS_MATH == fn)) {
         fn <- sprintf("Math.%s", fn)
+      } else if (any(names(FUNCTIONS_STOCHASTIC_SPECIAL) == fn)) {
+        fn <- sprintf("random.%s", FUNCTIONS_STOCHASTIC_SPECIAL[[fn]])
       }
       ## if (!any(names(FUNCTIONS) == fn)) {
       ##   stop(sprintf("unsupported function '%s' [odin bug]", fn)) # nocov
@@ -88,3 +94,35 @@ FUNCTIONS_MATH <- c(
   "cosh", "sinh", "tanh",
   "acosh", "asinh", "atanh",
   "abs", "floor", "round", "trunc")
+
+
+FUNCTIONS_STOCHASTIC_SPECIAL <- c(
+  unif_rand = "unifRand",
+  norm_rand = "normRand",
+  exp_rand = "expRand")
+
+
+FUNCTIONS_STOCHASTIC <- c(
+  ## TODO: I should write out these ones somewhere
+  ## And support many different distributions
+  ## rbeta = "", # a, b
+  rbinom = "binom", # n, p
+  ## rcauchy = "", # location, scale
+  ## rchisq = "", # df
+  rexp = 1L, # rate TODO: rewrite
+  ## rf = "", # n1, n2
+  ## rgamma = 2L, # shape, scale
+  rgeom = "geometric", # p
+  ## rhyper = "", # NR, NB, n
+  ## rlogis = "", # location, scale
+  ## rlnorm = "logNormal", # logmean, logsd - ignoring as hard to get right
+  ## rnbinom = "", # size, prob
+  rnorm = "normal", # mu, sigma
+  rpois = "poisson", # lambda
+  ## rt = "", # n
+  runif = "uniform" # a, b
+  ## rweibull = "", # shape, scale
+  ## rwilcox = "", # m, n
+  ## rmultinom = "", # n, p
+  ## rsignrank = "" # n
+)

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -30,7 +30,7 @@ generate_js_sexp <- function(x, data, meta) {
       ret <- generate_js_sexp_sum(args, data, meta)
     } else if (any(names(FUNCTIONS_STOCHASTIC) == fn)) {
       ret <- sprintf("random.%s(%s)()",
-                     FUNCTIONS_STOCHASTIC_SPECIAL[[fn]],
+                     FUNCTIONS_STOCHASTIC[[fn]],
                      paste(values, collapse = ", "))
     } else {
       if (any(FUNCTIONS_MATH == fn)) {
@@ -106,10 +106,10 @@ FUNCTIONS_STOCHASTIC <- c(
   ## TODO: I should write out these ones somewhere
   ## And support many different distributions
   ## rbeta = "", # a, b
-  rbinom = "binom", # n, p
+  rbinom = "rbinom", # n, p - note that this is patched
   ## rcauchy = "", # location, scale
   ## rchisq = "", # df
-  rexp = 1L, # rate TODO: rewrite
+  rexp = "exponential", # rate
   ## rf = "", # n1, n2
   ## rgamma = 2L, # shape, scale
   rgeom = "geometric", # p

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -102,6 +102,9 @@ R6_odin_js_wrapper <- R6::R6Class(
       if (is.null(tcrit)) {
         tcrit <- V8::JS("null")
       }
+
+      ## NOTE: tcrit here is ignored when calling the discrete time
+      ## model
       res <- private$context$call(sprintf("%s.run", private$name),
                                   t_js, y_js, tcrit)
       if (use_names) {
@@ -119,6 +122,7 @@ js_context <- function() {
     system.file(path, package = "odin.js", mustWork = TRUE)
   }
   ct$source(js_file("dopri.js"))
+  ct$source(js_file("discrete.js"))
   ct$source(js_file("support.js"))
   ct$source(js_file("interpolate.js"))
   ct$source(js_file("support_sum.js"))

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -126,6 +126,7 @@ js_context <- function() {
   ct$source(js_file("support.js"))
   ct$source(js_file("interpolate.js"))
   ct$source(js_file("support_sum.js"))
+  ct$source(js_file("random.js")) # TOOD: needs to be optional!
   ct$eval(sprintf("var %s = {};", JS_GENERATORS))
   ct$eval(sprintf("var %s = {};", JS_INSTANCES))
   ct

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -1,9 +1,8 @@
 ## We're going to want to call these models from R a lot for testing,
 ## so let's expose them as full R objects:
 odin_js_wrapper <- function(ir, options) {
-  context <- js_context()
-
   res <- generate_js(ir, options)
+  context <- js_context(names(which(res$include)))
   context$eval(paste(res$code, collapse = "\n"))
   name <- res$name
 
@@ -116,17 +115,18 @@ R6_odin_js_wrapper <- R6::R6Class(
 
 
 ##' @importFrom V8 v8
-js_context <- function() {
+js_context <- function(include) {
   ct <- V8::v8()
   js_file <- function(path) {
     system.file(path, package = "odin.js", mustWork = TRUE)
   }
+
   ct$source(js_file("dopri.js"))
-  ct$source(js_file("discrete.js"))
   ct$source(js_file("support.js"))
-  ct$source(js_file("interpolate.js"))
-  ct$source(js_file("support_sum.js"))
-  ct$source(js_file("random.js")) # TOOD: needs to be optional!
+  for (f in include) {
+    ct$source(js_file(f))
+  }
+
   ct$eval(sprintf("var %s = {};", JS_GENERATORS))
   ct$eval(sprintf("var %s = {};", JS_INSTANCES))
   ct

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,8 +64,8 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 - [x] arrays
 - [ ] delays
 - [x] interpolation
-- [ ] discrete models
-- [ ] stochastic models (this might be hard)
+- [x] discrete models
+- [x] stochastic models
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 - [x] arrays
 - [ ] delays
 - [x] interpolation
-- [ ] discrete models
-- [ ] stochastic models (this might be hard)
+- [x] discrete models
+- [x] stochastic models
 
 ---
 

--- a/inst/discrete.js
+++ b/inst/discrete.js
@@ -1,0 +1,59 @@
+function iterateOdin(obj, steps, y, nOut) {
+    if (isMissing(y)) {
+        y = obj.initial(steps[0]);
+    }
+    var update = function(step, y, yNext, output) {
+        obj.rhs(step, y, yNext, output);
+    }
+
+    return {"y": difeq(update, steps, y, nOut),
+            "names": obj.metadata.ynames.slice(0)};
+}
+
+
+function difeq(update, steps, y, nOut) {
+    var step = steps[0], stepEnd = steps[steps.length - 1];
+
+    var yNext = new Array(y.length);
+    var output = new Array(nOut);
+    var hasOutput = nOut > 0;
+    var storeNextOutput = hasOutput;
+
+    var ret = [];
+    var last = [step].concat(y);
+    ret.push(last);
+    var idx = 1;
+
+    while (true) {
+        update(step, y, yNext, output);
+        step++;
+        y = yNext;
+
+        if (storeNextOutput) {
+            for (var i = 0; i < nOut; ++i) {
+                last.push(output[i]);
+            }
+            storeNextOutput = false;
+        }
+
+        if (step == steps[idx]) {
+            last = [step].concat(y);
+            ret.push(last);
+            storeNextOutput = hasOutput;
+            idx++;
+        }
+
+        if (step == stepEnd) {
+            break;
+        }
+    }
+
+    if (storeNextOutput) {
+        update(step, y, yNext, output);
+        for (var i = 0; i < nOut; ++i) {
+            last.push(output[i]);
+        }
+    }
+
+    return ret;
+}

--- a/inst/discrete.js
+++ b/inst/discrete.js
@@ -1,4 +1,7 @@
 function iterateOdin(obj, steps, y, nOut) {
+    if (obj.metadata.interpolateTimes !== null) {
+        interpolateCheckT(steps, obj.metadata.interpolateTimes, null);
+    }
     if (isMissing(y)) {
         y = obj.initial(steps[0]);
     }

--- a/inst/random.js
+++ b/inst/random.js
@@ -2273,6 +2273,20 @@ global.random.unifRand = random.uniform();
 global.random.normRand = random.normal();
 global.random.expRand = random.exponential();
 
+// Patched to reflect R's behaviour and my needs:
+global.random.rbinom = function(n, p) {
+    n = Math.round(n);
+    var ret = null;
+    if (n === 0) {
+        ret = function() {
+            return 0;
+        }
+    } else {
+        ret = global.random.binomial(n, p);
+    }
+    return ret;
+}
+
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"random":23,"seedrandom":24}],33:[function(require,module,exports){
 

--- a/inst/random.js
+++ b/inst/random.js
@@ -1,0 +1,2274 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+'use strict'
+
+const symbols = require('./lib/symbols')
+const number = require('./lib/number')
+const string = require('./lib/string')
+const object = require('./lib/object')
+
+const typePredicates = {
+  number,
+  string,
+  object
+}
+
+const createOw = ({
+  validators = [],
+  predicates = typePredicates,
+  type = null
+} = { }) => {
+  const ow = new Proxy(function () { }, {
+    get: (obj, key) => {
+      if (key === symbols.validate) {
+        return (value, label = 'argument') => {
+          if (!type) {
+            return new Error('missing required type specifier')
+          }
+
+          for (let i = 0; i < validators.length; ++i) {
+            const validator = validators[i]
+            const result = validator.fn(value)
+
+            if (!result) {
+              if (i === 0) {
+                throw new Error(`Expected ${label} \`${value}\` to be of type \`${type}\`, but received type \`${typeof value}\``)
+              } else {
+                throw new Error(`Expected ${type} \`${label}\` \`${value}\` failed predicate \`${validator.key}\``)
+              }
+            }
+          }
+        }
+      }
+
+      const predicate = predicates[key]
+
+      if (predicate) {
+        if (typeof predicate === 'function') {
+          validators.push({
+            key,
+            fn: predicate
+          })
+
+          return ow
+        } else {
+          return createOw({
+            type: key,
+            validators: [
+              {
+                key,
+                fn: predicate.validator
+              }
+            ],
+            predicates: predicate.predicates
+          })
+        }
+      } else {
+        const fn = predicates[symbols.func] && predicates[symbols.func][key]
+
+        if (fn) {
+          return new Proxy(function () { }, {
+            get: () => {
+              throw new Error(`invalid use of functional predicate "${key}"`)
+            },
+
+            apply: (obj, thisArg, args) => {
+              validators.push({
+                key,
+                fn: fn(...args)
+              })
+
+              return ow
+            }
+          })
+        } else {
+          if (key === 'default' || key === '__esModule') {
+            return ow
+          }
+
+          return ow
+          // throw new Error(`unrecognized predicate "${key}"`)
+        }
+      }
+    },
+
+    apply: (obj, thisArg, args) => {
+      if (args.length !== 2 && args.length !== 3) {
+        throw new Error('invalid number of arguments to "ow"')
+      } else {
+        args[1][symbols.validate](args[0], args[2])
+      }
+    }
+  })
+
+  return ow
+}
+
+module.exports = createOw()
+
+},{"./lib/number":2,"./lib/object":3,"./lib/string":4,"./lib/symbols":5}],2:[function(require,module,exports){
+'use strict'
+
+const { func } = require('./symbols')
+
+const numberPredicates = {
+  positive: (value) => (value > 0),
+  negative: (value) => (value < 0),
+  nonNegative: (value) => (value >= 0),
+  integer: (value) => (value === (value | 0)),
+
+  [func]: {
+    is: (fn) => fn,
+    eq: (v) => (value) => (value === v),
+    gt: (v) => (value) => (value > v),
+    gte: (v) => (value) => (value >= v),
+    lt: (v) => (value) => (value < v),
+    lte: (v) => (value) => (value <= v)
+  }
+}
+
+module.exports = {
+  predicates: numberPredicates,
+  validator: (value) => {
+    return typeof value === 'number'
+  }
+}
+
+},{"./symbols":5}],3:[function(require,module,exports){
+'use strict'
+
+const { func } = require('./symbols')
+
+const objectPredicates = {
+  plain: (value) => {
+    if (typeof value !== 'object') return false
+
+    const proto = Object.getPrototypeOf(value)
+    return proto === null || proto === Object.getPrototypeOf({})
+  },
+  empty: (value) => Object.keys(value).length === 0,
+  nonEmpty: (value) => Object.keys(value).length > 0,
+
+  [func]: {
+    is: (fn) => fn,
+    instanceOf: (v) => (value) => (value instanceof v)
+  }
+}
+
+module.exports = {
+  predicates: objectPredicates,
+  validator: (value) => {
+    return typeof value === 'object'
+  }
+}
+
+},{"./symbols":5}],4:[function(require,module,exports){
+'use strict'
+
+const { func } = require('./symbols')
+
+const stringPredicates = {
+  empty: (value) => (value === ''),
+  nonEmpty: (value) => (value !== ''),
+
+  [func]: {
+    is: (fn) => fn,
+    eq: (v) => (value) => (value === v),
+    length: (v) => (value) => (value.length === v),
+    minLength: (v) => (value) => (value.length >= v),
+    maxLength: (v) => (value) => (value.length <= v),
+    matches: (v) => (value) => v.test(value),
+    startsWith: (v) => (value) => value.startsWith(v),
+    endsWith: (v) => (value) => value.endsWith(v)
+  }
+}
+
+module.exports = {
+  predicates: stringPredicates,
+  validator: (value) => {
+    return typeof value === 'string'
+  }
+}
+
+},{"./symbols":5}],5:[function(require,module,exports){
+'use strict'
+
+exports.func = Symbol('func')
+exports.validate = Symbol('validate')
+
+},{}],6:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+  (0, _owLite2.default)(n, _owLite2.default.number.integer.positive);
+  var irwinHall = random.irwinHall(n);
+
+  return function () {
+    return irwinHall() / n;
+  };
+};
+
+},{"ow-lite":1}],7:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0.5;
+
+  (0, _owLite2.default)(p, _owLite2.default.number.gte(0).lt(1));
+
+  return function () {
+    return random.next() + p | 0;
+  };
+};
+
+},{"ow-lite":1}],8:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+  var p = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0.5;
+
+  (0, _owLite2.default)(n, _owLite2.default.number.positive.integer);
+  (0, _owLite2.default)(p, _owLite2.default.number.gte(0).lte(1));
+
+  return function () {
+    var i = 0;
+    var x = 0;
+
+    while (i++ < n) {
+      x += random.next() < p;
+    }
+
+    return x;
+  };
+};
+
+},{"ow-lite":1}],9:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var lambda = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+  (0, _owLite2.default)(lambda, _owLite2.default.number.positive);
+
+  return function () {
+    return -Math.log(1 - random.next()) / lambda;
+  };
+};
+
+},{"ow-lite":1}],10:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0.5;
+
+  (0, _owLite2.default)(p, _owLite2.default.number.gt(0).lte(1));
+  var invLogP = 1.0 / Math.log(1.0 - p);
+
+  return function () {
+    return 1 + Math.log(random.next()) * invLogP | 0;
+  };
+};
+
+},{"ow-lite":1}],11:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+  (0, _owLite2.default)(n, _owLite2.default.number.integer.gte(0));
+
+  return function () {
+    var sum = 0;
+    for (var i = 0; i < n; ++i) {
+      sum += random.next();
+    }
+
+    return sum;
+  };
+};
+
+},{"ow-lite":1}],12:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function (random) {
+  for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    args[_key - 1] = arguments[_key];
+  }
+
+  var normal = random.normal.apply(random, args);
+
+  return function () {
+    return Math.exp(normal());
+  };
+};
+
+},{}],13:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var mu = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+  var sigma = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 1;
+
+  (0, _owLite2.default)(mu, _owLite2.default.number);
+  (0, _owLite2.default)(sigma, _owLite2.default.number);
+
+  return function () {
+    var x = void 0,
+        y = void 0,
+        r = void 0;
+
+    do {
+      x = random.next() * 2 - 1;
+      y = random.next() * 2 - 1;
+      r = x * x + y * y;
+    } while (!r || r > 1);
+
+    return mu + sigma * y * Math.sqrt(-2 * Math.log(r) / r);
+  };
+};
+
+},{"ow-lite":1}],14:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random) {
+  var alpha = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+  (0, _owLite2.default)(alpha, _owLite2.default.number.gte(0));
+  var invAlpha = 1.0 / alpha;
+
+  return function () {
+    return 1.0 / Math.pow(1.0 - random.next(), invAlpha);
+  };
+};
+
+},{"ow-lite":1}],15:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var logFactorialTable = [0.0, 0.0, 0.69314718055994529, 1.7917594692280550, 3.1780538303479458, 4.7874917427820458, 6.5792512120101012, 8.5251613610654147, 10.604602902745251, 12.801827480081469];
+
+var logFactorial = function logFactorial(k) {
+  return logFactorialTable[k];
+};
+
+var logSqrt2PI = 0.91893853320467267;
+
+exports.default = function (random) {
+  var lambda = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+  (0, _owLite2.default)(lambda, _owLite2.default.number.positive);
+
+  if (lambda < 10) {
+    // inversion method
+    var expMean = Math.exp(-lambda);
+
+    return function () {
+      var p = expMean;
+      var x = 0;
+      var u = random.next();
+
+      while (u > p) {
+        u = u - p;
+        p = lambda * p / ++x;
+      }
+
+      return x;
+    };
+  } else {
+    // generative method
+    var smu = Math.sqrt(lambda);
+    var b = 0.931 + 2.53 * smu;
+    var a = -0.059 + 0.02483 * b;
+    var invAlpha = 1.1239 + 1.1328 / (b - 3.4);
+    var vR = 0.9277 - 3.6224 / (b - 2);
+
+    return function () {
+      while (true) {
+        var u = void 0;
+        var v = random.next();
+
+        if (v <= 0.86 * vR) {
+          u = v / vR - 0.43;
+          return Math.floor((2 * a / (0.5 - Math.abs(u)) + b) * u + lambda + 0.445);
+        }
+
+        if (v >= vR) {
+          u = random.next() - 0.5;
+        } else {
+          u = v / vR - 0.93;
+          u = (u < 0 ? -0.5 : 0.5) - u;
+          v = random.next() * vR;
+        }
+
+        var us = 0.5 - Math.abs(u);
+        if (us < 0.013 && v > us) {
+          continue;
+        }
+
+        var k = Math.floor((2 * a / us + b) * u + lambda + 0.445) | 0;
+        v = v * invAlpha / (a / (us * us) + b);
+
+        if (k >= 10) {
+          var t = (k + 0.5) * Math.log(lambda / k) - lambda - logSqrt2PI + k - (1 / 12.0 - (1 / 360.0 - 1 / (1260.0 * k * k)) / (k * k)) / k;
+
+          if (Math.log(v * smu) <= t) {
+            return k;
+          }
+        } else if (k >= 0) {
+          if (Math.log(v) <= k * Math.log(lambda) - lambda - logFactorial(k)) {
+            return k;
+          }
+        }
+      }
+    };
+  }
+};
+
+},{"ow-lite":1}],16:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function (random) {
+  return function () {
+    return random.next() >= 0.5;
+  };
+};
+
+},{}],17:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random, min, max) {
+  if (max === undefined) {
+    max = min === undefined ? 1 : min;
+    min = 0;
+  }
+
+  (0, _owLite2.default)(min, _owLite2.default.number.integer);
+  (0, _owLite2.default)(max, _owLite2.default.number.integer);
+
+  return function () {
+    return random.next() * (max - min + 1) + min | 0;
+  };
+};
+
+},{"ow-lite":1}],18:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (random, min, max) {
+  if (max === undefined) {
+    max = min === undefined ? 1 : min;
+    min = 0;
+  }
+
+  (0, _owLite2.default)(min, _owLite2.default.number);
+  (0, _owLite2.default)(max, _owLite2.default.number);
+
+  return function () {
+    return random.next() * (max - min) + min;
+  };
+};
+
+},{"ow-lite":1}],19:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+var _rng = require('../rng');
+
+var _rng2 = _interopRequireDefault(_rng);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var RNGFunction = function (_RNG) {
+  _inherits(RNGFunction, _RNG);
+
+  function RNGFunction(thunk, opts) {
+    _classCallCheck(this, RNGFunction);
+
+    var _this = _possibleConstructorReturn(this, (RNGFunction.__proto__ || Object.getPrototypeOf(RNGFunction)).call(this));
+
+    _this.seed(thunk, opts);
+    return _this;
+  }
+
+  _createClass(RNGFunction, [{
+    key: 'next',
+    value: function next() {
+      return this._rng();
+    }
+  }, {
+    key: 'seed',
+    value: function seed(thunk) {
+      (0, _owLite2.default)(thunk, _owLite2.default.function);
+      this._rng = thunk;
+    }
+  }, {
+    key: 'clone',
+    value: function clone() {
+      for (var _len = arguments.length, opts = Array(_len), _key = 0; _key < _len; _key++) {
+        opts[_key] = arguments[_key];
+      }
+
+      return new (Function.prototype.bind.apply(RNGFunction, [null].concat([this._rng], opts)))();
+    }
+  }, {
+    key: 'name',
+    get: function get() {
+      return 'function';
+    }
+  }]);
+
+  return RNGFunction;
+}(_rng2.default);
+
+exports.default = RNGFunction;
+
+},{"../rng":22,"ow-lite":1}],20:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.RNGFactory = exports.RNG = undefined;
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _owLite = require('ow-lite');
+
+var _owLite2 = _interopRequireDefault(_owLite);
+
+var _rng = require('./rng');
+
+var _rng2 = _interopRequireDefault(_rng);
+
+var _rngFactory = require('./rng-factory');
+
+var _rngFactory2 = _interopRequireDefault(_rngFactory);
+
+var _uniform2 = require('./distributions/uniform');
+
+var _uniform3 = _interopRequireDefault(_uniform2);
+
+var _uniformInt2 = require('./distributions/uniform-int');
+
+var _uniformInt3 = _interopRequireDefault(_uniformInt2);
+
+var _uniformBoolean2 = require('./distributions/uniform-boolean');
+
+var _uniformBoolean3 = _interopRequireDefault(_uniformBoolean2);
+
+var _normal2 = require('./distributions/normal');
+
+var _normal3 = _interopRequireDefault(_normal2);
+
+var _logNormal2 = require('./distributions/log-normal');
+
+var _logNormal3 = _interopRequireDefault(_logNormal2);
+
+var _bernoulli2 = require('./distributions/bernoulli');
+
+var _bernoulli3 = _interopRequireDefault(_bernoulli2);
+
+var _binomial2 = require('./distributions/binomial');
+
+var _binomial3 = _interopRequireDefault(_binomial2);
+
+var _geometric2 = require('./distributions/geometric');
+
+var _geometric3 = _interopRequireDefault(_geometric2);
+
+var _poisson2 = require('./distributions/poisson');
+
+var _poisson3 = _interopRequireDefault(_poisson2);
+
+var _exponential2 = require('./distributions/exponential');
+
+var _exponential3 = _interopRequireDefault(_exponential2);
+
+var _irwinHall2 = require('./distributions/irwin-hall');
+
+var _irwinHall3 = _interopRequireDefault(_irwinHall2);
+
+var _bates2 = require('./distributions/bates');
+
+var _bates3 = _interopRequireDefault(_bates2);
+
+var _pareto2 = require('./distributions/pareto');
+
+var _pareto3 = _interopRequireDefault(_pareto2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+exports.RNG = _rng2.default;
+exports.RNGFactory = _rngFactory2.default;
+
+/**
+ * Seedable random number generator supporting many common distributions.
+ *
+ * Defaults to Math.random as its underlying pseudorandom number generator.
+ *
+ * @name Random
+ * @class
+ *
+ * @param {RNG|function} [rng=Math.random] - Underlying pseudorandom number generator.
+ */
+
+var Random = function () {
+  function Random(rng) {
+    _classCallCheck(this, Random);
+
+    if (rng) (0, _owLite2.default)(rng, _owLite2.default.object.instanceOf(_rng2.default));
+
+    this._cache = {};
+    this.use(rng);
+  }
+
+  /**
+   * @member {RNG} Underlying pseudo-random number generator
+   */
+
+
+  _createClass(Random, [{
+    key: 'clone',
+
+
+    /**
+     * Creates a new `Random` instance, optionally specifying parameters to
+     * set a new seed.
+     *
+     * @see RNG.clone
+     *
+     * @param {string} [seed] - Optional seed for new RNG.
+     * @param {object} [opts] - Optional config for new RNG options.
+     * @return {Random}
+     */
+    value: function clone() {
+      if (arguments.length) {
+        return new Random(_rngFactory2.default.apply(undefined, arguments));
+      } else {
+        return new Random(this.rng.clone());
+      }
+    }
+
+    /**
+     * Sets the underlying pseudorandom number generator used via
+     * either an instance of `seedrandom`, a custom instance of RNG
+     * (for PRNG plugins), or a string specifying the PRNG to use
+     * along with an optional `seed` and `opts` to initialize the
+     * RNG.
+     *
+     * @example
+     * const random = require('random')
+     *
+     * random.use('example_seedrandom_string')
+     * // or
+     * random.use(seedrandom('kittens'))
+     * // or
+     * random.use(Math.random)
+     *
+     * @param {...*} args
+     */
+
+  }, {
+    key: 'use',
+    value: function use() {
+      this._rng = _rngFactory2.default.apply(undefined, arguments);
+    }
+
+    /**
+     * Patches `Math.random` with this Random instance's PRNG.
+     */
+
+  }, {
+    key: 'patch',
+    value: function patch() {
+      if (this._patch) {
+        throw new Error('Math.random already patched');
+      }
+
+      this._patch = Math.random;
+      Math.random = this.uniform();
+    }
+
+    /**
+     * Restores a previously patched `Math.random` to its original value.
+     */
+
+  }, {
+    key: 'unpatch',
+    value: function unpatch() {
+      if (this._patch) {
+        Math.random = this._patch;
+        delete this._patch;
+      }
+    }
+
+    // --------------------------------------------------------------------------
+    // Uniform utility functions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Convenience wrapper around `this.rng.next()`
+     *
+     * Returns a floating point number in [0, 1).
+     *
+     * @return {number}
+     */
+
+  }, {
+    key: 'next',
+    value: function next() {
+      return this._rng.next();
+    }
+
+    /**
+     * Samples a uniform random floating point number, optionally specifying
+     * lower and upper bounds.
+     *
+     * Convence wrapper around `random.uniform()`
+     *
+     * @param {number} [min=0] - Lower bound (float, inclusive)
+     * @param {number} [max=1] - Upper bound (float, exclusive)
+     * @return {number}
+     */
+
+  }, {
+    key: 'float',
+    value: function float(min, max) {
+      return this.uniform(min, max)();
+    }
+
+    /**
+     * Samples a uniform random integer, optionally specifying lower and upper
+     * bounds.
+     *
+     * Convence wrapper around `random.uniformInt()`
+     *
+     * @param {number} [min=0] - Lower bound (integer, inclusive)
+     * @param {number} [max=1] - Upper bound (integer, inclusive)
+     * @return {number}
+     */
+
+  }, {
+    key: 'int',
+    value: function int(min, max) {
+      return this.uniformInt(min, max)();
+    }
+
+    /**
+     * Samples a uniform random integer, optionally specifying lower and upper
+     * bounds.
+     *
+     * Convence wrapper around `random.uniformInt()`
+     *
+     * @alias `random.int`
+     *
+     * @param {number} [min=0] - Lower bound (integer, inclusive)
+     * @param {number} [max=1] - Upper bound (integer, inclusive)
+     * @return {number}
+     */
+
+  }, {
+    key: 'integer',
+    value: function integer(min, max) {
+      return this.uniformInt(min, max)();
+    }
+
+    /**
+     * Samples a uniform random boolean value.
+     *
+     * Convence wrapper around `random.uniformBoolean()`
+     *
+     * @alias `random.boolean`
+     *
+     * @return {boolean}
+     */
+
+  }, {
+    key: 'bool',
+    value: function bool() {
+      return this.uniformBoolean()();
+    }
+
+    /**
+     * Samples a uniform random boolean value.
+     *
+     * Convence wrapper around `random.uniformBoolean()`
+     *
+     * @return {boolean}
+     */
+
+  }, {
+    key: 'boolean',
+    value: function boolean() {
+      return this.uniformBoolean()();
+    }
+
+    // --------------------------------------------------------------------------
+    // Uniform distributions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates a [Continuous uniform distribution](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)).
+     *
+     * @param {number} [min=0] - Lower bound (float, inclusive)
+     * @param {number} [max=1] - Upper bound (float, exclusive)
+     * @return {function}
+     */
+
+  }, {
+    key: 'uniform',
+    value: function uniform(min, max) {
+      return this._memoize('uniform', _uniform3.default, min, max);
+    }
+
+    /**
+     * Generates a [Discrete uniform distribution](https://en.wikipedia.org/wiki/Discrete_uniform_distribution).
+     *
+     * @param {number} [min=0] - Lower bound (integer, inclusive)
+     * @param {number} [max=1] - Upper bound (integer, inclusive)
+     * @return {function}
+     */
+
+  }, {
+    key: 'uniformInt',
+    value: function uniformInt(min, max) {
+      return this._memoize('uniformInt', _uniformInt3.default, min, max);
+    }
+
+    /**
+     * Generates a [Discrete uniform distribution](https://en.wikipedia.org/wiki/Discrete_uniform_distribution),
+     * with two possible outcomes, `true` or `false.
+     *
+     * This method is analogous to flipping a coin.
+     *
+     * @return {function}
+     */
+
+  }, {
+    key: 'uniformBoolean',
+    value: function uniformBoolean() {
+      return this._memoize('uniformBoolean', _uniformBoolean3.default);
+    }
+
+    // --------------------------------------------------------------------------
+    // Normal distributions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates a [Normal distribution](https://en.wikipedia.org/wiki/Normal_distribution).
+     *
+     * @param {number} [mu=0] - Mean
+     * @param {number} [sigma=1] - Standard deviation
+     * @return {function}
+     */
+
+  }, {
+    key: 'normal',
+    value: function normal(mu, sigma) {
+      return (0, _normal3.default)(this, mu, sigma);
+    }
+
+    /**
+     * Generates a [Log-normal distribution](https://en.wikipedia.org/wiki/Log-normal_distribution).
+     *
+     * @param {number} [mu=0] - Mean of underlying normal distribution
+     * @param {number} [sigma=1] - Standard deviation of underlying normal distribution
+     * @return {function}
+     */
+
+  }, {
+    key: 'logNormal',
+    value: function logNormal(mu, sigma) {
+      return (0, _logNormal3.default)(this, mu, sigma);
+    }
+
+    // --------------------------------------------------------------------------
+    // Bernoulli distributions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates a [Bernoulli distribution](https://en.wikipedia.org/wiki/Bernoulli_distribution).
+     *
+     * @param {number} [p=0.5] - Success probability of each trial.
+     * @return {function}
+     */
+
+  }, {
+    key: 'bernoulli',
+    value: function bernoulli(p) {
+      return (0, _bernoulli3.default)(this, p);
+    }
+
+    /**
+     * Generates a [Binomial distribution](https://en.wikipedia.org/wiki/Binomial_distribution).
+     *
+     * @param {number} [n=1] - Number of trials.
+     * @param {number} [p=0.5] - Success probability of each trial.
+     * @return {function}
+     */
+
+  }, {
+    key: 'binomial',
+    value: function binomial(n, p) {
+      return (0, _binomial3.default)(this, n, p);
+    }
+
+    /**
+     * Generates a [Geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution).
+     *
+     * @param {number} [p=0.5] - Success probability of each trial.
+     * @return {function}
+     */
+
+  }, {
+    key: 'geometric',
+    value: function geometric(p) {
+      return (0, _geometric3.default)(this, p);
+    }
+
+    // --------------------------------------------------------------------------
+    // Poisson distributions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates a [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution).
+     *
+     * @param {number} [lambda=1] - Mean (lambda > 0)
+     * @return {function}
+     */
+
+  }, {
+    key: 'poisson',
+    value: function poisson(lambda) {
+      return (0, _poisson3.default)(this, lambda);
+    }
+
+    /**
+     * Generates an [Exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution).
+     *
+     * @param {number} [lambda=1] - Inverse mean (lambda > 0)
+     * @return {function}
+     */
+
+  }, {
+    key: 'exponential',
+    value: function exponential(lambda) {
+      return (0, _exponential3.default)(this, lambda);
+    }
+
+    // --------------------------------------------------------------------------
+    // Misc distributions
+    // --------------------------------------------------------------------------
+
+    /**
+     * Generates an [Irwin Hall distribution](https://en.wikipedia.org/wiki/Irwin%E2%80%93Hall_distribution).
+     *
+     * @param {number} [n=1] - Number of uniform samples to sum (n >= 0)
+     * @return {function}
+     */
+
+  }, {
+    key: 'irwinHall',
+    value: function irwinHall(n) {
+      return (0, _irwinHall3.default)(this, n);
+    }
+
+    /**
+     * Generates a [Bates distribution](https://en.wikipedia.org/wiki/Bates_distribution).
+     *
+     * @param {number} [n=1] - Number of uniform samples to average (n >= 1)
+     * @return {function}
+     */
+
+  }, {
+    key: 'bates',
+    value: function bates(n) {
+      return (0, _bates3.default)(this, n);
+    }
+
+    /**
+     * Generates a [Pareto distribution](https://en.wikipedia.org/wiki/Pareto_distribution).
+     *
+     * @param {number} [alpha=1] - Alpha
+     * @return {function}
+     */
+
+  }, {
+    key: 'pareto',
+    value: function pareto(alpha) {
+      return (0, _pareto3.default)(this, alpha);
+    }
+
+    // --------------------------------------------------------------------------
+    // Internal
+    // --------------------------------------------------------------------------
+
+    /**
+     * Memoizes distributions to ensure they're only created when necessary.
+     *
+     * Returns a thunk which that returns independent, identically distributed
+     * samples from the specified distribution.
+     *
+     * @private
+     *
+     * @param {string} label - Name of distribution
+     * @param {function} getter - Function which generates a new distribution
+     * @param {...*} args - Distribution-specific arguments
+     *
+     * @return {function}
+     */
+
+  }, {
+    key: '_memoize',
+    value: function _memoize(label, getter) {
+      for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+        args[_key - 2] = arguments[_key];
+      }
+
+      var key = '' + args.join(';');
+      var value = this._cache[label];
+
+      if (value === undefined || value.key !== key) {
+        value = { key: key, distribution: getter.apply(undefined, [this].concat(args)) };
+        this._cache[label] = value;
+      }
+
+      return value.distribution;
+    }
+  }, {
+    key: 'rng',
+    get: function get() {
+      return this._rng;
+    }
+  }]);
+
+  return Random;
+}();
+
+// defaults to Math.random as its RNG
+
+
+exports.default = new Random();
+
+},{"./distributions/bates":6,"./distributions/bernoulli":7,"./distributions/binomial":8,"./distributions/exponential":9,"./distributions/geometric":10,"./distributions/irwin-hall":11,"./distributions/log-normal":12,"./distributions/normal":13,"./distributions/pareto":14,"./distributions/poisson":15,"./distributions/uniform":18,"./distributions/uniform-boolean":16,"./distributions/uniform-int":17,"./rng":22,"./rng-factory":21,"ow-lite":1}],21:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _seedrandom = require('seedrandom');
+
+var _seedrandom2 = _interopRequireDefault(_seedrandom);
+
+var _rng = require('./rng');
+
+var _rng2 = _interopRequireDefault(_rng);
+
+var _function = require('./generators/function');
+
+var _function2 = _interopRequireDefault(_function);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+exports.default = function () {
+  for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  var _args$ = args[0],
+      arg0 = _args$ === undefined ? 'default' : _args$,
+      rest = args.slice(1);
+
+
+  switch (typeof arg0 === 'undefined' ? 'undefined' : _typeof(arg0)) {
+    case 'object':
+      if (arg0 instanceof _rng2.default) {
+        return arg0;
+      }
+      break;
+
+    case 'function':
+      return new _function2.default(arg0);
+
+    case 'string':
+    case 'number':
+      return new _function2.default(_seedrandom2.default.apply(undefined, _toConsumableArray(rest)));
+  }
+
+  throw new Error('invalid RNG "' + arg0 + '"');
+};
+
+},{"./generators/function":19,"./rng":22,"seedrandom":24}],22:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var RNG = function () {
+  function RNG() {
+    _classCallCheck(this, RNG);
+  }
+
+  _createClass(RNG, [{
+    key: 'next',
+    value: function next() {
+      throw new Error('RNG.next must be overridden');
+    }
+  }, {
+    key: 'seed',
+    value: function seed(_seed, opts) {
+      throw new Error('RNG.seed must be overridden');
+    }
+  }, {
+    key: 'clone',
+    value: function clone(seed, opts) {
+      throw new Error('RNG.clone must be overridden');
+    }
+  }, {
+    key: '_seed',
+    value: function _seed(seed, opts) {
+      // TODO: add entropy and stuff
+
+      if (seed === (seed | 0)) {
+        return seed;
+      } else {
+        var strSeed = '' + seed;
+        var s = 0;
+
+        for (var k = 0; k < strSeed.length; ++k) {
+          s ^= strSeed.charCodeAt(k) | 0;
+        }
+
+        return s;
+      }
+    }
+  }, {
+    key: 'name',
+    get: function get() {
+      throw new Error('RNG.name must be overridden');
+    }
+  }]);
+
+  return RNG;
+}();
+
+exports.default = RNG;
+
+},{}],23:[function(require,module,exports){
+'use strict'
+
+module.exports = require('./dist/random').default
+
+},{"./dist/random":20}],24:[function(require,module,exports){
+// A library of seedable RNGs implemented in Javascript.
+//
+// Usage:
+//
+// var seedrandom = require('seedrandom');
+// var random = seedrandom(1); // or any seed.
+// var x = random();       // 0 <= x < 1.  Every bit is random.
+// var x = random.quick(); // 0 <= x < 1.  32 bits of randomness.
+
+// alea, a 53-bit multiply-with-carry generator by Johannes Baagøe.
+// Period: ~2^116
+// Reported to pass all BigCrush tests.
+var alea = require('./lib/alea');
+
+// xor128, a pure xor-shift generator by George Marsaglia.
+// Period: 2^128-1.
+// Reported to fail: MatrixRank and LinearComp.
+var xor128 = require('./lib/xor128');
+
+// xorwow, George Marsaglia's 160-bit xor-shift combined plus weyl.
+// Period: 2^192-2^32
+// Reported to fail: CollisionOver, SimpPoker, and LinearComp.
+var xorwow = require('./lib/xorwow');
+
+// xorshift7, by François Panneton and Pierre L'ecuyer, takes
+// a different approach: it adds robustness by allowing more shifts
+// than Marsaglia's original three.  It is a 7-shift generator
+// with 256 bits, that passes BigCrush with no systmatic failures.
+// Period 2^256-1.
+// No systematic BigCrush failures reported.
+var xorshift7 = require('./lib/xorshift7');
+
+// xor4096, by Richard Brent, is a 4096-bit xor-shift with a
+// very long period that also adds a Weyl generator. It also passes
+// BigCrush with no systematic failures.  Its long period may
+// be useful if you have many generators and need to avoid
+// collisions.
+// Period: 2^4128-2^32.
+// No systematic BigCrush failures reported.
+var xor4096 = require('./lib/xor4096');
+
+// Tyche-i, by Samuel Neves and Filipe Araujo, is a bit-shifting random
+// number generator derived from ChaCha, a modern stream cipher.
+// https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
+// Period: ~2^127
+// No systematic BigCrush failures reported.
+var tychei = require('./lib/tychei');
+
+// The original ARC4-based prng included in this library.
+// Period: ~2^1600
+var sr = require('./seedrandom');
+
+sr.alea = alea;
+sr.xor128 = xor128;
+sr.xorwow = xorwow;
+sr.xorshift7 = xorshift7;
+sr.xor4096 = xor4096;
+sr.tychei = tychei;
+
+module.exports = sr;
+
+},{"./lib/alea":25,"./lib/tychei":26,"./lib/xor128":27,"./lib/xor4096":28,"./lib/xorshift7":29,"./lib/xorwow":30,"./seedrandom":31}],25:[function(require,module,exports){
+// A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
+// http://baagoe.com/en/RandomMusings/javascript/
+// https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
+// Original work is under MIT license -
+
+// Copyright (C) 2010 by Johannes Baagøe <baagoe@baagoe.org>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+
+(function(global, module, define) {
+
+function Alea(seed) {
+  var me = this, mash = Mash();
+
+  me.next = function() {
+    var t = 2091639 * me.s0 + me.c * 2.3283064365386963e-10; // 2^-32
+    me.s0 = me.s1;
+    me.s1 = me.s2;
+    return me.s2 = t - (me.c = t | 0);
+  };
+
+  // Apply the seeding algorithm from Baagoe.
+  me.c = 1;
+  me.s0 = mash(' ');
+  me.s1 = mash(' ');
+  me.s2 = mash(' ');
+  me.s0 -= mash(seed);
+  if (me.s0 < 0) { me.s0 += 1; }
+  me.s1 -= mash(seed);
+  if (me.s1 < 0) { me.s1 += 1; }
+  me.s2 -= mash(seed);
+  if (me.s2 < 0) { me.s2 += 1; }
+  mash = null;
+}
+
+function copy(f, t) {
+  t.c = f.c;
+  t.s0 = f.s0;
+  t.s1 = f.s1;
+  t.s2 = f.s2;
+  return t;
+}
+
+function impl(seed, opts) {
+  var xg = new Alea(seed),
+      state = opts && opts.state,
+      prng = xg.next;
+  prng.int32 = function() { return (xg.next() * 0x100000000) | 0; }
+  prng.double = function() {
+    return prng() + (prng() * 0x200000 | 0) * 1.1102230246251565e-16; // 2^-53
+  };
+  prng.quick = prng;
+  if (state) {
+    if (typeof(state) == 'object') copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+function Mash() {
+  var n = 0xefc8249d;
+
+  var mash = function(data) {
+    data = String(data);
+    for (var i = 0; i < data.length; i++) {
+      n += data.charCodeAt(i);
+      var h = 0.02519603282416938 * n;
+      n = h >>> 0;
+      h -= n;
+      h *= n;
+      n = h >>> 0;
+      h -= n;
+      n += h * 0x100000000; // 2^32
+    }
+    return (n >>> 0) * 2.3283064365386963e-10; // 2^-32
+  };
+
+  return mash;
+}
+
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.alea = impl;
+}
+
+})(
+  this,
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+
+
+},{}],26:[function(require,module,exports){
+// A Javascript implementaion of the "Tyche-i" prng algorithm by
+// Samuel Neves and Filipe Araujo.
+// See https://eden.dei.uc.pt/~sneves/pubs/2011-snfa2.pdf
+
+(function(global, module, define) {
+
+function XorGen(seed) {
+  var me = this, strseed = '';
+
+  // Set up generator function.
+  me.next = function() {
+    var b = me.b, c = me.c, d = me.d, a = me.a;
+    b = (b << 25) ^ (b >>> 7) ^ c;
+    c = (c - d) | 0;
+    d = (d << 24) ^ (d >>> 8) ^ a;
+    a = (a - b) | 0;
+    me.b = b = (b << 20) ^ (b >>> 12) ^ c;
+    me.c = c = (c - d) | 0;
+    me.d = (d << 16) ^ (c >>> 16) ^ a;
+    return me.a = (a - b) | 0;
+  };
+
+  /* The following is non-inverted tyche, which has better internal
+   * bit diffusion, but which is about 25% slower than tyche-i in JS.
+  me.next = function() {
+    var a = me.a, b = me.b, c = me.c, d = me.d;
+    a = (me.a + me.b | 0) >>> 0;
+    d = me.d ^ a; d = d << 16 ^ d >>> 16;
+    c = me.c + d | 0;
+    b = me.b ^ c; b = b << 12 ^ d >>> 20;
+    me.a = a = a + b | 0;
+    d = d ^ a; me.d = d = d << 8 ^ d >>> 24;
+    me.c = c = c + d | 0;
+    b = b ^ c;
+    return me.b = (b << 7 ^ b >>> 25);
+  }
+  */
+
+  me.a = 0;
+  me.b = 0;
+  me.c = 2654435769 | 0;
+  me.d = 1367130551;
+
+  if (seed === Math.floor(seed)) {
+    // Integer seed.
+    me.a = (seed / 0x100000000) | 0;
+    me.b = seed | 0;
+  } else {
+    // String seed.
+    strseed += seed;
+  }
+
+  // Mix in string seed, then discard an initial batch of 64 values.
+  for (var k = 0; k < strseed.length + 20; k++) {
+    me.b ^= strseed.charCodeAt(k) | 0;
+    me.next();
+  }
+}
+
+function copy(f, t) {
+  t.a = f.a;
+  t.b = f.b;
+  t.c = f.c;
+  t.d = f.d;
+  return t;
+};
+
+function impl(seed, opts) {
+  var xg = new XorGen(seed),
+      state = opts && opts.state,
+      prng = function() { return (xg.next() >>> 0) / 0x100000000; };
+  prng.double = function() {
+    do {
+      var top = xg.next() >>> 11,
+          bot = (xg.next() >>> 0) / 0x100000000,
+          result = (top + bot) / (1 << 21);
+    } while (result === 0);
+    return result;
+  };
+  prng.int32 = xg.next;
+  prng.quick = prng;
+  if (state) {
+    if (typeof(state) == 'object') copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.tychei = impl;
+}
+
+})(
+  this,
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+
+
+},{}],27:[function(require,module,exports){
+// A Javascript implementaion of the "xor128" prng algorithm by
+// George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
+
+(function(global, module, define) {
+
+function XorGen(seed) {
+  var me = this, strseed = '';
+
+  me.x = 0;
+  me.y = 0;
+  me.z = 0;
+  me.w = 0;
+
+  // Set up generator function.
+  me.next = function() {
+    var t = me.x ^ (me.x << 11);
+    me.x = me.y;
+    me.y = me.z;
+    me.z = me.w;
+    return me.w ^= (me.w >>> 19) ^ t ^ (t >>> 8);
+  };
+
+  if (seed === (seed | 0)) {
+    // Integer seed.
+    me.x = seed;
+  } else {
+    // String seed.
+    strseed += seed;
+  }
+
+  // Mix in string seed, then discard an initial batch of 64 values.
+  for (var k = 0; k < strseed.length + 64; k++) {
+    me.x ^= strseed.charCodeAt(k) | 0;
+    me.next();
+  }
+}
+
+function copy(f, t) {
+  t.x = f.x;
+  t.y = f.y;
+  t.z = f.z;
+  t.w = f.w;
+  return t;
+}
+
+function impl(seed, opts) {
+  var xg = new XorGen(seed),
+      state = opts && opts.state,
+      prng = function() { return (xg.next() >>> 0) / 0x100000000; };
+  prng.double = function() {
+    do {
+      var top = xg.next() >>> 11,
+          bot = (xg.next() >>> 0) / 0x100000000,
+          result = (top + bot) / (1 << 21);
+    } while (result === 0);
+    return result;
+  };
+  prng.int32 = xg.next;
+  prng.quick = prng;
+  if (state) {
+    if (typeof(state) == 'object') copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.xor128 = impl;
+}
+
+})(
+  this,
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+
+
+},{}],28:[function(require,module,exports){
+// A Javascript implementaion of Richard Brent's Xorgens xor4096 algorithm.
+//
+// This fast non-cryptographic random number generator is designed for
+// use in Monte-Carlo algorithms. It combines a long-period xorshift
+// generator with a Weyl generator, and it passes all common batteries
+// of stasticial tests for randomness while consuming only a few nanoseconds
+// for each prng generated.  For background on the generator, see Brent's
+// paper: "Some long-period random number generators using shifts and xors."
+// http://arxiv.org/pdf/1004.3115v1.pdf
+//
+// Usage:
+//
+// var xor4096 = require('xor4096');
+// random = xor4096(1);                        // Seed with int32 or string.
+// assert.equal(random(), 0.1520436450538547); // (0, 1) range, 53 bits.
+// assert.equal(random.int32(), 1806534897);   // signed int32, 32 bits.
+//
+// For nonzero numeric keys, this impelementation provides a sequence
+// identical to that by Brent's xorgens 3 implementaion in C.  This
+// implementation also provides for initalizing the generator with
+// string seeds, or for saving and restoring the state of the generator.
+//
+// On Chrome, this prng benchmarks about 2.1 times slower than
+// Javascript's built-in Math.random().
+
+(function(global, module, define) {
+
+function XorGen(seed) {
+  var me = this;
+
+  // Set up generator function.
+  me.next = function() {
+    var w = me.w,
+        X = me.X, i = me.i, t, v;
+    // Update Weyl generator.
+    me.w = w = (w + 0x61c88647) | 0;
+    // Update xor generator.
+    v = X[(i + 34) & 127];
+    t = X[i = ((i + 1) & 127)];
+    v ^= v << 13;
+    t ^= t << 17;
+    v ^= v >>> 15;
+    t ^= t >>> 12;
+    // Update Xor generator array state.
+    v = X[i] = v ^ t;
+    me.i = i;
+    // Result is the combination.
+    return (v + (w ^ (w >>> 16))) | 0;
+  };
+
+  function init(me, seed) {
+    var t, v, i, j, w, X = [], limit = 128;
+    if (seed === (seed | 0)) {
+      // Numeric seeds initialize v, which is used to generates X.
+      v = seed;
+      seed = null;
+    } else {
+      // String seeds are mixed into v and X one character at a time.
+      seed = seed + '\0';
+      v = 0;
+      limit = Math.max(limit, seed.length);
+    }
+    // Initialize circular array and weyl value.
+    for (i = 0, j = -32; j < limit; ++j) {
+      // Put the unicode characters into the array, and shuffle them.
+      if (seed) v ^= seed.charCodeAt((j + 32) % seed.length);
+      // After 32 shuffles, take v as the starting w value.
+      if (j === 0) w = v;
+      v ^= v << 10;
+      v ^= v >>> 15;
+      v ^= v << 4;
+      v ^= v >>> 13;
+      if (j >= 0) {
+        w = (w + 0x61c88647) | 0;     // Weyl.
+        t = (X[j & 127] ^= (v + w));  // Combine xor and weyl to init array.
+        i = (0 == t) ? i + 1 : 0;     // Count zeroes.
+      }
+    }
+    // We have detected all zeroes; make the key nonzero.
+    if (i >= 128) {
+      X[(seed && seed.length || 0) & 127] = -1;
+    }
+    // Run the generator 512 times to further mix the state before using it.
+    // Factoring this as a function slows the main generator, so it is just
+    // unrolled here.  The weyl generator is not advanced while warming up.
+    i = 127;
+    for (j = 4 * 128; j > 0; --j) {
+      v = X[(i + 34) & 127];
+      t = X[i = ((i + 1) & 127)];
+      v ^= v << 13;
+      t ^= t << 17;
+      v ^= v >>> 15;
+      t ^= t >>> 12;
+      X[i] = v ^ t;
+    }
+    // Storing state as object members is faster than using closure variables.
+    me.w = w;
+    me.X = X;
+    me.i = i;
+  }
+
+  init(me, seed);
+}
+
+function copy(f, t) {
+  t.i = f.i;
+  t.w = f.w;
+  t.X = f.X.slice();
+  return t;
+};
+
+function impl(seed, opts) {
+  if (seed == null) seed = +(new Date);
+  var xg = new XorGen(seed),
+      state = opts && opts.state,
+      prng = function() { return (xg.next() >>> 0) / 0x100000000; };
+  prng.double = function() {
+    do {
+      var top = xg.next() >>> 11,
+          bot = (xg.next() >>> 0) / 0x100000000,
+          result = (top + bot) / (1 << 21);
+    } while (result === 0);
+    return result;
+  };
+  prng.int32 = xg.next;
+  prng.quick = prng;
+  if (state) {
+    if (state.X) copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.xor4096 = impl;
+}
+
+})(
+  this,                                     // window object or global
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+},{}],29:[function(require,module,exports){
+// A Javascript implementaion of the "xorshift7" algorithm by
+// François Panneton and Pierre L'ecuyer:
+// "On the Xorgshift Random Number Generators"
+// http://saluc.engr.uconn.edu/refs/crypto/rng/panneton05onthexorshift.pdf
+
+(function(global, module, define) {
+
+function XorGen(seed) {
+  var me = this;
+
+  // Set up generator function.
+  me.next = function() {
+    // Update xor generator.
+    var X = me.x, i = me.i, t, v, w;
+    t = X[i]; t ^= (t >>> 7); v = t ^ (t << 24);
+    t = X[(i + 1) & 7]; v ^= t ^ (t >>> 10);
+    t = X[(i + 3) & 7]; v ^= t ^ (t >>> 3);
+    t = X[(i + 4) & 7]; v ^= t ^ (t << 7);
+    t = X[(i + 7) & 7]; t = t ^ (t << 13); v ^= t ^ (t << 9);
+    X[i] = v;
+    me.i = (i + 1) & 7;
+    return v;
+  };
+
+  function init(me, seed) {
+    var j, w, X = [];
+
+    if (seed === (seed | 0)) {
+      // Seed state array using a 32-bit integer.
+      w = X[0] = seed;
+    } else {
+      // Seed state using a string.
+      seed = '' + seed;
+      for (j = 0; j < seed.length; ++j) {
+        X[j & 7] = (X[j & 7] << 15) ^
+            (seed.charCodeAt(j) + X[(j + 1) & 7] << 13);
+      }
+    }
+    // Enforce an array length of 8, not all zeroes.
+    while (X.length < 8) X.push(0);
+    for (j = 0; j < 8 && X[j] === 0; ++j);
+    if (j == 8) w = X[7] = -1; else w = X[j];
+
+    me.x = X;
+    me.i = 0;
+
+    // Discard an initial 256 values.
+    for (j = 256; j > 0; --j) {
+      me.next();
+    }
+  }
+
+  init(me, seed);
+}
+
+function copy(f, t) {
+  t.x = f.x.slice();
+  t.i = f.i;
+  return t;
+}
+
+function impl(seed, opts) {
+  if (seed == null) seed = +(new Date);
+  var xg = new XorGen(seed),
+      state = opts && opts.state,
+      prng = function() { return (xg.next() >>> 0) / 0x100000000; };
+  prng.double = function() {
+    do {
+      var top = xg.next() >>> 11,
+          bot = (xg.next() >>> 0) / 0x100000000,
+          result = (top + bot) / (1 << 21);
+    } while (result === 0);
+    return result;
+  };
+  prng.int32 = xg.next;
+  prng.quick = prng;
+  if (state) {
+    if (state.x) copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.xorshift7 = impl;
+}
+
+})(
+  this,
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+
+},{}],30:[function(require,module,exports){
+// A Javascript implementaion of the "xorwow" prng algorithm by
+// George Marsaglia.  See http://www.jstatsoft.org/v08/i14/paper
+
+(function(global, module, define) {
+
+function XorGen(seed) {
+  var me = this, strseed = '';
+
+  // Set up generator function.
+  me.next = function() {
+    var t = (me.x ^ (me.x >>> 2));
+    me.x = me.y; me.y = me.z; me.z = me.w; me.w = me.v;
+    return (me.d = (me.d + 362437 | 0)) +
+       (me.v = (me.v ^ (me.v << 4)) ^ (t ^ (t << 1))) | 0;
+  };
+
+  me.x = 0;
+  me.y = 0;
+  me.z = 0;
+  me.w = 0;
+  me.v = 0;
+
+  if (seed === (seed | 0)) {
+    // Integer seed.
+    me.x = seed;
+  } else {
+    // String seed.
+    strseed += seed;
+  }
+
+  // Mix in string seed, then discard an initial batch of 64 values.
+  for (var k = 0; k < strseed.length + 64; k++) {
+    me.x ^= strseed.charCodeAt(k) | 0;
+    if (k == strseed.length) {
+      me.d = me.x << 10 ^ me.x >>> 4;
+    }
+    me.next();
+  }
+}
+
+function copy(f, t) {
+  t.x = f.x;
+  t.y = f.y;
+  t.z = f.z;
+  t.w = f.w;
+  t.v = f.v;
+  t.d = f.d;
+  return t;
+}
+
+function impl(seed, opts) {
+  var xg = new XorGen(seed),
+      state = opts && opts.state,
+      prng = function() { return (xg.next() >>> 0) / 0x100000000; };
+  prng.double = function() {
+    do {
+      var top = xg.next() >>> 11,
+          bot = (xg.next() >>> 0) / 0x100000000,
+          result = (top + bot) / (1 << 21);
+    } while (result === 0);
+    return result;
+  };
+  prng.int32 = xg.next;
+  prng.quick = prng;
+  if (state) {
+    if (typeof(state) == 'object') copy(state, xg);
+    prng.state = function() { return copy(xg, {}); }
+  }
+  return prng;
+}
+
+if (module && module.exports) {
+  module.exports = impl;
+} else if (define && define.amd) {
+  define(function() { return impl; });
+} else {
+  this.xorwow = impl;
+}
+
+})(
+  this,
+  (typeof module) == 'object' && module,    // present in node.js
+  (typeof define) == 'function' && define   // present with an AMD loader
+);
+
+
+
+},{}],31:[function(require,module,exports){
+/*
+Copyright 2019 David Bau.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+(function (global, pool, math) {
+//
+// The following constants are related to IEEE 754 limits.
+//
+
+var width = 256,        // each RC4 output is 0 <= x < 256
+    chunks = 6,         // at least six RC4 outputs for each double
+    digits = 52,        // there are 52 significant digits in a double
+    rngname = 'random', // rngname: name for Math.random and Math.seedrandom
+    startdenom = math.pow(width, chunks),
+    significance = math.pow(2, digits),
+    overflow = significance * 2,
+    mask = width - 1,
+    nodecrypto;         // node.js crypto module, initialized at the bottom.
+
+//
+// seedrandom()
+// This is the seedrandom function described above.
+//
+function seedrandom(seed, options, callback) {
+  var key = [];
+  options = (options == true) ? { entropy: true } : (options || {});
+
+  // Flatten the seed string or build one from local entropy if needed.
+  var shortseed = mixkey(flatten(
+    options.entropy ? [seed, tostring(pool)] :
+    (seed == null) ? autoseed() : seed, 3), key);
+
+  // Use the seed to initialize an ARC4 generator.
+  var arc4 = new ARC4(key);
+
+  // This function returns a random double in [0, 1) that contains
+  // randomness in every bit of the mantissa of the IEEE 754 value.
+  var prng = function() {
+    var n = arc4.g(chunks),             // Start with a numerator n < 2 ^ 48
+        d = startdenom,                 //   and denominator d = 2 ^ 48.
+        x = 0;                          //   and no 'extra last byte'.
+    while (n < significance) {          // Fill up all significant digits by
+      n = (n + x) * width;              //   shifting numerator and
+      d *= width;                       //   denominator and generating a
+      x = arc4.g(1);                    //   new least-significant-byte.
+    }
+    while (n >= overflow) {             // To avoid rounding up, before adding
+      n /= 2;                           //   last byte, shift everything
+      d /= 2;                           //   right using integer math until
+      x >>>= 1;                         //   we have exactly the desired bits.
+    }
+    return (n + x) / d;                 // Form the number within [0, 1).
+  };
+
+  prng.int32 = function() { return arc4.g(4) | 0; }
+  prng.quick = function() { return arc4.g(4) / 0x100000000; }
+  prng.double = prng;
+
+  // Mix the randomness into accumulated entropy.
+  mixkey(tostring(arc4.S), pool);
+
+  // Calling convention: what to return as a function of prng, seed, is_math.
+  return (options.pass || callback ||
+      function(prng, seed, is_math_call, state) {
+        if (state) {
+          // Load the arc4 state from the given state if it has an S array.
+          if (state.S) { copy(state, arc4); }
+          // Only provide the .state method if requested via options.state.
+          prng.state = function() { return copy(arc4, {}); }
+        }
+
+        // If called as a method of Math (Math.seedrandom()), mutate
+        // Math.random because that is how seedrandom.js has worked since v1.0.
+        if (is_math_call) { math[rngname] = prng; return seed; }
+
+        // Otherwise, it is a newer calling convention, so return the
+        // prng directly.
+        else return prng;
+      })(
+  prng,
+  shortseed,
+  'global' in options ? options.global : (this == math),
+  options.state);
+}
+
+//
+// ARC4
+//
+// An ARC4 implementation.  The constructor takes a key in the form of
+// an array of at most (width) integers that should be 0 <= x < (width).
+//
+// The g(count) method returns a pseudorandom integer that concatenates
+// the next (count) outputs from ARC4.  Its return value is a number x
+// that is in the range 0 <= x < (width ^ count).
+//
+function ARC4(key) {
+  var t, keylen = key.length,
+      me = this, i = 0, j = me.i = me.j = 0, s = me.S = [];
+
+  // The empty key [] is treated as [0].
+  if (!keylen) { key = [keylen++]; }
+
+  // Set up S using the standard key scheduling algorithm.
+  while (i < width) {
+    s[i] = i++;
+  }
+  for (i = 0; i < width; i++) {
+    s[i] = s[j = mask & (j + key[i % keylen] + (t = s[i]))];
+    s[j] = t;
+  }
+
+  // The "g" method returns the next (count) outputs as one number.
+  (me.g = function(count) {
+    // Using instance members instead of closure state nearly doubles speed.
+    var t, r = 0,
+        i = me.i, j = me.j, s = me.S;
+    while (count--) {
+      t = s[i = mask & (i + 1)];
+      r = r * width + s[mask & ((s[i] = s[j = mask & (j + t)]) + (s[j] = t))];
+    }
+    me.i = i; me.j = j;
+    return r;
+    // For robust unpredictability, the function call below automatically
+    // discards an initial batch of values.  This is called RC4-drop[256].
+    // See http://google.com/search?q=rsa+fluhrer+response&btnI
+  })(width);
+}
+
+//
+// copy()
+// Copies internal state of ARC4 to or from a plain object.
+//
+function copy(f, t) {
+  t.i = f.i;
+  t.j = f.j;
+  t.S = f.S.slice();
+  return t;
+};
+
+//
+// flatten()
+// Converts an object tree to nested arrays of strings.
+//
+function flatten(obj, depth) {
+  var result = [], typ = (typeof obj), prop;
+  if (depth && typ == 'object') {
+    for (prop in obj) {
+      try { result.push(flatten(obj[prop], depth - 1)); } catch (e) {}
+    }
+  }
+  return (result.length ? result : typ == 'string' ? obj : obj + '\0');
+}
+
+//
+// mixkey()
+// Mixes a string seed into a key that is an array of integers, and
+// returns a shortened string seed that is equivalent to the result key.
+//
+function mixkey(seed, key) {
+  var stringseed = seed + '', smear, j = 0;
+  while (j < stringseed.length) {
+    key[mask & j] =
+      mask & ((smear ^= key[mask & j] * 19) + stringseed.charCodeAt(j++));
+  }
+  return tostring(key);
+}
+
+//
+// autoseed()
+// Returns an object for autoseeding, using window.crypto and Node crypto
+// module if available.
+//
+function autoseed() {
+  try {
+    var out;
+    if (nodecrypto && (out = nodecrypto.randomBytes)) {
+      // The use of 'out' to remember randomBytes makes tight minified code.
+      out = out(width);
+    } else {
+      out = new Uint8Array(width);
+      (global.crypto || global.msCrypto).getRandomValues(out);
+    }
+    return tostring(out);
+  } catch (e) {
+    var browser = global.navigator,
+        plugins = browser && browser.plugins;
+    return [+new Date, global, plugins, global.screen, tostring(pool)];
+  }
+}
+
+//
+// tostring()
+// Converts an array of charcodes to a string
+//
+function tostring(a) {
+  return String.fromCharCode.apply(0, a);
+}
+
+//
+// When seedrandom.js is loaded, we immediately mix a few bits
+// from the built-in RNG into the entropy pool.  Because we do
+// not want to interfere with deterministic PRNG state later,
+// seedrandom will not call math.random on its own again after
+// initialization.
+//
+mixkey(math.random(), pool);
+
+//
+// Nodejs and AMD support: export the implementation as a module using
+// either convention.
+//
+if ((typeof module) == 'object' && module.exports) {
+  module.exports = seedrandom;
+  // When in node.js, try using crypto package for autoseeding.
+  try {
+    nodecrypto = require('crypto');
+  } catch (ex) {}
+} else if ((typeof define) == 'function' && define.amd) {
+  define(function() { return seedrandom; });
+} else {
+  // When included as a plain script, set up Math.seedrandom global.
+  math['seed' + rngname] = seedrandom;
+}
+
+
+// End anonymous scope, and pass initial values.
+})(
+  // global: `self` in browsers (including strict mode and web workers),
+  // otherwise `this` in Node and other environments
+  (typeof self !== 'undefined') ? self : this,
+  [],     // pool: entropy pool starts empty
+  Math    // math: package containing random, pow, and seedrandom
+);
+
+},{"crypto":33}],32:[function(require,module,exports){
+(function (global){
+global.random = require("random");
+// Configure sensible drop-in replacements for R's functions:
+global.random.unifRand = random.uniform();
+global.random.unifNorm = random.normal();
+global.random.unifExp = random.exponential();
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"random":23}],33:[function(require,module,exports){
+
+},{}]},{},[32]);

--- a/inst/random.js
+++ b/inst/random.js
@@ -2262,13 +2262,18 @@ if ((typeof module) == 'object' && module.exports) {
 
 },{"crypto":33}],32:[function(require,module,exports){
 (function (global){
+global.seedrandom = require("seedrandom");
 global.random = require("random");
+global.random.use(seedrandom("odin.js"));
+global.setSeed = function(seed) {
+    global.random.use(seedrandom(seed));
+}
 // Configure sensible drop-in replacements for R's functions:
 global.random.unifRand = random.uniform();
-global.random.unifNorm = random.normal();
-global.random.unifExp = random.exponential();
+global.random.normRand = random.normal();
+global.random.expRand = random.exponential();
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"random":23}],33:[function(require,module,exports){
+},{"random":23,"seedrandom":24}],33:[function(require,module,exports){
 
 },{}]},{},[32]);

--- a/js/build
+++ b/js/build
@@ -11,3 +11,4 @@ rm -rf node_modules
 npm install
 
 browserify dopri.in.js > $DEST/dopri.js
+browserify random.in.js > $DEST/random.js

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -4,10 +4,55 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "core-js": {
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
         "dopri": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.7.tgz",
             "integrity": "sha512-17vUmybOB3aFFMXD9/cjU7z9z2MH6eLkVj0UVewu6RmhhuYOUId2n4uowRTKHRwmQNNqxQsXtFyGMa9py8a5iA=="
+        },
+        "ow": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/ow/-/ow-0.4.0.tgz",
+            "integrity": "sha512-kJNzxUgVd6EF5LoGs+s2/etJPwjfRDLXPTCfEgV8At77sRrV+PSFA8lcoW2HF15Qd455mIR2Stee/2MzDiFBDA=="
+        },
+        "ow-lite": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/ow-lite/-/ow-lite-0.0.2.tgz",
+            "integrity": "sha1-359QDmdAtlkKHpqWVzDUmo61l9E="
+        },
+        "random": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/random/-/random-2.2.0.tgz",
+            "integrity": "sha512-4HBR4Xye4jJ41QBi6RfIaO1yKQpxVUZafQtdE6NvvjzirNlwWgsk3tkGLTbQtWUarF4ofZsUVEmWqB1TDQlkwA==",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "ow": "^0.4.0",
+                "ow-lite": "^0.0.2",
+                "seedrandom": "^3.0.5"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
         }
     }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,8 @@
         "url": "https://github.com/mrc-ide/odin.js/issues"
     },
     "dependencies": {
-        "dopri": "^0.0.7"
+        "dopri": "^0.0.7",
+        "random": "^2.2.0"
     },
     "homepage": "https://github.com/mrc-ide/odin.js#readme"
 }

--- a/js/random.in.js
+++ b/js/random.in.js
@@ -8,3 +8,17 @@ global.setSeed = function(seed) {
 global.random.unifRand = random.uniform();
 global.random.normRand = random.normal();
 global.random.expRand = random.exponential();
+
+// Patched to reflect R's behaviour and my needs:
+global.random.rbinom = function(n, p) {
+    n = Math.round(n);
+    var ret = null;
+    if (n === 0) {
+        ret = function() {
+            return 0;
+        }
+    } else {
+        ret = global.random.binomial(n, p);
+    }
+    return ret;
+}

--- a/js/random.in.js
+++ b/js/random.in.js
@@ -1,0 +1,5 @@
+global.random = require("random");
+// Configure sensible drop-in replacements for R's functions:
+global.random.unifRand = random.uniform();
+global.random.unifNorm = random.normal();
+global.random.unifExp = random.exponential();

--- a/js/random.in.js
+++ b/js/random.in.js
@@ -1,5 +1,10 @@
+global.seedrandom = require("seedrandom");
 global.random = require("random");
+global.random.use(seedrandom("odin.js"));
+global.setSeed = function(seed) {
+    global.random.use(seedrandom(seed));
+}
 // Configure sensible drop-in replacements for R's functions:
 global.random.unifRand = random.uniform();
-global.random.unifNorm = random.normal();
-global.random.unifExp = random.exponential();
+global.random.normRand = random.normal();
+global.random.expRand = random.exponential();

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -84,6 +84,22 @@ model_context <- function(x) {
   environment(x$initialize)$private$context
 }
 
+
 model_set_seed <- function(x, seed) {
   model_context(x)$call("setSeed", seed)
+}
+
+
+model_random_numbers <- function(x, name, n, ...) {
+  ctx <- model_context(x)
+  ctx$eval(c(
+    "var repeat = function(f, n) {",
+    "  var ret = [];",
+    "  for (var i = 0; i < n; ++i) {",
+    "    ret.push(f());",
+    "  }",
+    "  return ret;",
+    "}"))
+  f <- V8::JS(sprintf("random.%s(%s)", name, paste(c(...), collapse = ", ")))
+  ctx$call("repeat", f, n)
 }

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -25,6 +25,30 @@ odin_js_support <- function() {
 }
 
 
+odin_js_test_random <- function(name) {
+  skip_if_no_random_js()
+  force(name)
+  v8 <- V8::v8()
+  v8$eval(package_js("random.js"))
+
+  v8$eval(c(
+    "var repeat = function(f, n) {",
+    "  var ret = [];",
+    "  for (var i = 0; i < n; ++i) {",
+    "    ret.push(f());",
+    "  }",
+    "  return ret;",
+    "}"))
+
+  ## TODO: set the seed, and make sure we're using seedrandom
+  function(n, parameters) {
+    f <- V8::JS(sprintf("random.%s(%s)",
+                        name, paste(parameters, collapse = ", ")))
+    v8$call("repeat", f, n)
+  }
+}
+
+
 expect_js_error <- function(...) {
   testthat::expect_error(..., class = "std::runtime_error")
 }
@@ -32,4 +56,25 @@ expect_js_error <- function(...) {
 
 to_json_max <- function(x) {
   V8::JS(jsonlite::toJSON(x, digits = NA))
+}
+
+
+## Requires newish node:
+random_js_supported <- local({
+  supported <- NULL
+  function() {
+    if (is.null(supported)) {
+      supported <<- !is.null(tryCatch(
+                       V8::v8()$eval(package_js("random.js")),
+                       error = function(e) NULL))
+    }
+    supported
+  }
+})
+
+
+skip_if_no_random_js <- function() {
+  if (!random_js_supported()) {
+    testthat::skip("random.js not supported on your v8 version")
+  }
 }

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -80,6 +80,10 @@ skip_if_no_random_js <- function() {
 }
 
 
+model_context <- function(x) {
+  environment(x$initialize)$private$context
+}
+
 model_set_seed <- function(x, seed) {
-  environment(x$initialize)$private$context$call("setSeed", seed)
+  model_context(x)$call("setSeed", seed)
 }

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -78,3 +78,8 @@ skip_if_no_random_js <- function() {
     testthat::skip("random.js not supported on your v8 version")
   }
 }
+
+
+model_set_seed <- function(x, seed) {
+  environment(x$initialize)$private$context$call("setSeed", seed)
+}

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -152,3 +152,27 @@ test_that("include fancy sum", {
   cmp <- odin::odin_(code, target = "r")(user = user)$run(tt)
   expect_equivalent(yy, cmp[], tolerance = 1e-5)
 })
+
+
+test_that("simple stochastic model in a bundle", {
+  code <- c(
+    "initial(x) <- 0",
+    "update(x) <- x + norm_rand()")
+
+  p <- tempfile()
+  dir.create(p)
+  filename <- file.path(p, "odin.R")
+  writeLines(code, filename)
+  res <- odin_js_bundle(filename)
+
+  ct <- V8::v8()
+  invisible(ct$source(res))
+  ct$call("setSeed", 1)
+  tt <- 0:20
+  yy <- call_odin_bundle(ct, "odin", NULL, tt)
+
+  mod <- odin_js_(code)()
+  model_set_seed(mod, 1)
+  cmp <- mod$run(tt)
+  expect_equal(yy, cmp)
+})

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -110,16 +110,6 @@ test_that("user variables", {
 })
 
 
-test_that("discrete models are not supported", {
-  expect_error(
-    odin_js({
-      initial(x) <- 1
-      update(x) <- x + 1
-    }),
-    "Using unsupported features: 'discrete'")
-})
-
-
 test_that("delay models are not supported", {
   expect_error(
     odin_js({

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -209,14 +209,13 @@ test_that("copy output", {
 
 ## Basic discrete models
 test_that("discrete", {
-  skip("Needs implementing")
   gen <- odin_js({
     initial(x) <- 1
     update(x) <- x + 1
   })
   mod <- gen()
 
-  expect_equal(mod$initial(), 1)
+  expect_equal(mod$initial(0), 1)
   expect_equal(mod$update(0, 1), 2)
 
   tt <- 0:10
@@ -226,7 +225,6 @@ test_that("discrete", {
 
 
 test_that("discrete with output", {
-  skip("Needs implementing")
   gen <- odin_js({
     initial(x) <- 1
     update(x) <- x + 1

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -1,0 +1,182 @@
+context("run: discrete")
+
+test_that("basic", {
+  gen <- odin_js({
+    initial(x) <- 1
+    update(x) <- x + 1
+  })
+
+  mod <- gen()
+  expect_equal(mod$contents(), list(initial_x = 1))
+  y0 <- mod$initial(0)
+  expect_equal(y0, 1.0)
+  expect_equal(mod$update(0L, y0), 2.0)
+
+  tt <- 0:10
+  res <- mod$run(tt)
+
+  expect_equal(res, cbind(step = tt, x = 1:11))
+})
+
+test_that("output", {
+  gen <- odin_js({
+    initial(x[]) <- x0[i]
+    update(x[]) <- x[i] + r[i]
+    x0[] <- user()
+    r[] <- user()
+    dim(x0) <- user()
+    dim(x) <- length(x0)
+    dim(r) <- length(x)
+    output(total) <- sum(x)
+  })
+
+  x0 <- runif(10)
+  r <- runif(length(x0))
+
+  mod <- gen(x0 = x0, r = r)
+
+  tt <- 0:10
+  yy <- mod$run(tt)
+  ## zz <- mod$transform_variables(yy)
+  zz <- list(x = unname(yy[, 2:11]), total = yy[, 12])
+
+  expect_equal(zz$x, t(outer(r, tt) + x0))
+  expect_equal(zz$total, rowSums(zz$x))
+})
+
+test_that("interpolate", {
+  gen <- odin_js({
+    initial(x) <- 0
+    update(x) <- x + pulse
+    pulse <- interpolate(sp, zp, "constant")
+    sp[] <- user()
+    zp[] <- user()
+    dim(sp) <- user()
+    dim(zp) <- length(sp)
+  })
+
+  sp <- c(0, 10, 20)
+  zp <- c(0, 1, 0)
+  expect_js_error(gen(sp = sp, zp = zp[1:2]),
+                  "Expected length 3 value for 'zp'")
+  expect_js_error(gen(sp = sp, zp = rep(zp, 2)),
+                  "Expected length 3 value for 'zp'")
+
+  mod <- gen(sp = sp, zp = zp)
+
+  tt <- 0:30
+  expect_js_error(mod$run(tt - 1L),
+                  "Integration times do not span interpolation")
+
+  yy <- mod$run(tt)
+  zz <- cumsum(ifelse(tt <= 10 | tt > 20, 0, 1))
+  expect_equal(yy[, 2], zz)
+})
+
+test_that("use step in model", {
+  gen <- odin_js({
+    initial(x) <- step
+    update(x) <- step + 1
+  })
+
+  mod <- gen()
+  res <- mod$run(5:10)
+  expect_equal(res[, "x"], res[, "step"])
+})
+
+## This is to avoid a regression with array_dim_name
+test_that("2d array equations", {
+  gen <- odin_js({
+    initial(x[,]) <- x0[i, j]
+    update(x[,]) <- x[i, j] + r[i, j]
+    x0[,] <- user()
+    r[,] <- user()
+    dim(x0) <- user()
+    dim(x) <- c(dim(x0, 1), dim(x0, 2))
+    dim(r) <- c(dim(x0, 1), dim(x0, 2))
+  })
+
+  r <- matrix(runif(10), 2, 5)
+  x0 <- matrix(runif(10), 2, 5)
+
+  mod <- gen(x0 = x0, r = r)
+  yy <- mod$run(0:10)
+
+  expect_equal(mod$contents()$x0, c(x0)) # TODO - reshape
+  expect_equal(matrix(mod$initial(0), 2, 5), x0)
+
+  expect_equal(unname(diff(yy)[1, ]), c(1, c(r)))
+  expect_equal(unname(diff(yy)[10, ]), c(1, c(r)))
+})
+
+## This turns up in one of Neil's cases:
+test_that("complex initialisation: scalar", {
+  skip("needs stochastic")
+  gen <- odin_js({
+    initial(x1) <- norm_rand()
+    r <- x1 * 2
+    initial(x2) <- r + 1
+    update(x1) <- x1 + r
+    update(x2) <- x2 + r
+  })
+
+  gen2 <- odin_js({
+    x1_0 <- user()
+    initial(x1) <- x1_0
+    r <- x1 * 2
+    initial(x2) <- r + 1
+    update(x1) <- x1 + r
+    update(x2) <- x2 + r
+  })
+
+  set.seed(1)
+  mod <- gen()
+
+  v <- mod$initial(0)
+  vv <- mod$transform_variables(v)
+
+  set.seed(1)
+  x1 <- rnorm(1)
+  expect_equal(vv$x1, x1)
+  expect_equal(vv$x2, x1 * 2 + 1)
+
+  mod2 <- gen2(x1)
+  v2 <- mod2$initial(0)
+  expect_equal(v2, v)
+
+  set.seed(1)
+  z <- mod$run(0:5)
+  z2 <- mod2$run(0:5)
+  expect_equal(z, z2)
+
+  ## TODO: we never actually check here that the values are correct.
+  ## It's a bit of an odd model because r grows with x1
+})
+
+test_that("complex initialisation: vector", {
+  skip("needs stochastic")
+  gen <- odin_js({
+    initial(x1[]) <- norm_rand()
+    r[] <- x1[i] * 2
+    initial(x2[]) <- r[i] + 1
+
+    update(x1[]) <- x1[i] + r[i]
+    update(x2[]) <- x2[i] + r[i]
+
+    dim(x1) <- 10
+    dim(r) <- length(x1)
+    dim(x2) <- length(x1)
+  })
+
+  set.seed(1)
+  mod <- gen()
+
+  v <- mod$initial(0)
+  vv <- mod$transform_variables(v)
+
+  set.seed(1)
+  cmp <- rnorm(10)
+  expect_equal(vv$x1, cmp)
+  expect_equal(vv$x2, cmp * 2 + 1)
+  expect_equal(mod$contents()$r, cmp * 2)
+})

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -111,6 +111,7 @@ test_that("2d array equations", {
 
 ## This turns up in one of Neil's cases:
 test_that("complex initialisation: scalar", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(x1) <- norm_rand()
     r <- x1 * 2
@@ -157,6 +158,7 @@ test_that("complex initialisation: scalar", {
 })
 
 test_that("complex initialisation: vector", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(x1[]) <- norm_rand()
     r[] <- x1[i] * 2

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -111,7 +111,6 @@ test_that("2d array equations", {
 
 ## This turns up in one of Neil's cases:
 test_that("complex initialisation: scalar", {
-  skip("needs stochastic")
   gen <- odin_js({
     initial(x1) <- norm_rand()
     r <- x1 * 2
@@ -129,22 +128,27 @@ test_that("complex initialisation: scalar", {
     update(x2) <- x2 + r
   })
 
-  set.seed(1)
   mod <- gen()
+  ctx <- environment(mod$initialize)$private$context
+  model_set_seed(mod, 1)
 
   v <- mod$initial(0)
-  vv <- mod$transform_variables(v)
+  ## vv <- mod$transform_variables(v)
+  vv <- list(x1 = v[[1]], x2 = v[[2]])
 
-  set.seed(1)
-  x1 <- rnorm(1)
+  ## set.seed(1)
+  ## x1 <- rnorm(1)
+  model_set_seed(mod, 1)
+  x1 <- ctx$call("random.normRand")
   expect_equal(vv$x1, x1)
   expect_equal(vv$x2, x1 * 2 + 1)
 
-  mod2 <- gen2(x1)
+  mod2 <- gen2(x1_0 = x1)
   v2 <- mod2$initial(0)
   expect_equal(v2, v)
 
-  set.seed(1)
+  ## set.seed(1)
+  model_set_seed(mod, 1)
   z <- mod$run(0:5)
   z2 <- mod2$run(0:5)
   expect_equal(z, z2)

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -129,7 +129,6 @@ test_that("complex initialisation: scalar", {
   })
 
   mod <- gen()
-  ctx <- environment(mod$initialize)$private$context
   model_set_seed(mod, 1)
 
   v <- mod$initial(0)
@@ -139,7 +138,7 @@ test_that("complex initialisation: scalar", {
   ## set.seed(1)
   ## x1 <- rnorm(1)
   model_set_seed(mod, 1)
-  x1 <- ctx$call("random.normRand")
+  x1 <- model_context(mod)$call("random.normRand")
   expect_equal(vv$x1, x1)
   expect_equal(vv$x2, x1 * 2 + 1)
 
@@ -158,7 +157,6 @@ test_that("complex initialisation: scalar", {
 })
 
 test_that("complex initialisation: vector", {
-  skip("needs stochastic")
   gen <- odin_js({
     initial(x1[]) <- norm_rand()
     r[] <- x1[i] * 2
@@ -172,14 +170,16 @@ test_that("complex initialisation: vector", {
     dim(x2) <- length(x1)
   })
 
-  set.seed(1)
   mod <- gen()
-
+  model_set_seed(mod, 1)
   v <- mod$initial(0)
-  vv <- mod$transform_variables(v)
+  ## vv <- mod$transform_variables(v)
+  vv <- list(x1 = v[1:10], x2 = v[11:20])
 
-  set.seed(1)
-  cmp <- rnorm(10)
+  model_set_seed(mod, 1)
+  ctx <- model_context(mod)
+  cmp <- vapply(1:10, function(i) ctx$call("random.normRand"), numeric(1))
+
   expect_equal(vv$x1, cmp)
   expect_equal(vv$x2, cmp * 2 + 1)
   expect_equal(mod$contents()$r, cmp * 2)

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -126,7 +126,6 @@ test_that("exotic stochastic functions", {
 
 
 test_that("round & rbinom", {
-  skip("WIP")
   gen <- odin_js({
     size <- user()
     p <- user()
@@ -136,8 +135,7 @@ test_that("round & rbinom", {
 
   mod <- gen(p = 1, size = 0.4)
   expect_equal(mod$initial(0), 0)
-  mod$set_user(p = 1, size = 1.7)
-  mod <- gen(p = 1, size = 1.7)
+  mod$set_user(list(p = 1, size = 1.7))
   expect_equal(mod$initial(0), 2)
 })
 

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -1,6 +1,7 @@
 context("run:stochastic")
 
 test_that("stochastic", {
+  skip_if_no_random_js()
   ## Here's a stochastic random walk:
   gen <- odin_js({
     initial(x) <- 0
@@ -27,6 +28,7 @@ test_that("stochastic", {
 ## variable that is used only in the initial condition I do not want
 ## that repeatedly called during the run.
 test_that("stochastic variables are time dependent", {
+  skip_if_no_random_js()
   gen <- odin_js({
     v <- norm_rand() # this variable is implicitly time dependent.
     initial(x) <- 0
@@ -45,6 +47,7 @@ test_that("stochastic variables are time dependent", {
 
 
 test_that("array stochastic variables are time dependent", {
+  skip_if_no_random_js()
   ## This checks that even in the absence of array indexing on the RHS
   ## array variables are set correctly when stochastic.
   gen <- odin_js({
@@ -67,6 +70,7 @@ test_that("array stochastic variables are time dependent", {
 
 
 test_that("stochastic initial conditions don't get called every step", {
+  skip_if_no_random_js()
   ## There is quite a few nasty little conditions that are tested
   ## here.
   gen <- odin_js({
@@ -109,6 +113,7 @@ test_that("stochastic initial conditions don't get called every step", {
 
 
 test_that("exotic stochastic functions", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(x) <- 0
     mu <- 1
@@ -126,6 +131,7 @@ test_that("exotic stochastic functions", {
 
 
 test_that("round & rbinom", {
+  skip_if_no_random_js()
   gen <- odin_js({
     size <- user()
     p <- user()
@@ -141,6 +147,7 @@ test_that("round & rbinom", {
 
 
 test_that("mutlinomial", {
+  skip_if_no_random_js()
   skip("multinomial not supported")
   ## This is just a check that these compile and run
   sir1 <- odin_js("stochastic/sir_discrete.R")
@@ -166,6 +173,7 @@ test_that("mutlinomial", {
 
 
 test_that("replicate: scalar", {
+  skip_if_no_random_js()
   skip("replicate not supported")
   ## TODO: this will be a nice version to try and benchmark the dde
   ## overheads I think...
@@ -186,6 +194,7 @@ test_that("replicate: scalar", {
 
 
 test_that("replicate: array", {
+  skip_if_no_random_js()
   skip("replicate not supported")
   gen <- odin_js({
     initial(x) <- 0
@@ -210,6 +219,7 @@ test_that("replicate: array", {
 
 
 test_that("low-level stochastics: norm_rand", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- norm_rand()
@@ -226,6 +236,7 @@ test_that("low-level stochastics: norm_rand", {
 
 
 test_that("low-level stochastics: unif_rand", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- unif_rand()
@@ -242,6 +253,7 @@ test_that("low-level stochastics: unif_rand", {
 
 
 test_that("low-level stochastics: exp_rand", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- exp_rand()
@@ -258,6 +270,7 @@ test_that("low-level stochastics: exp_rand", {
 
 
 test_that("rexp parametrisation", {
+  skip_if_no_random_js()
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- rexp(10)

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -1,0 +1,279 @@
+context("run:stochastic")
+
+test_that("stochastic", {
+  ## Here's a stochastic random walk:
+  gen <- odin_js({
+    initial(x) <- 0
+    update(x) <- x + norm_rand()
+  })
+
+  mod <- gen()
+  tt <- 0:20
+  model_set_seed(mod, 1)
+  yy1 <- mod$run(tt)
+
+  model_set_seed(mod, 1)
+  cmp <- model_random_numbers(mod, "normal", length(tt) - 1L)
+  expect_equal(cumsum(c(0, cmp)), yy1[, "x"])
+
+  ## Repeatable
+  model_set_seed(mod, 1)
+  yy2 <- mod$run(tt)
+  expect_equal(yy1, yy2)
+})
+
+
+## I'm not totally sure what the right call is here.  If I make a
+## variable that is used only in the initial condition I do not want
+## that repeatedly called during the run.
+test_that("stochastic variables are time dependent", {
+  gen <- odin_js({
+    v <- norm_rand() # this variable is implicitly time dependent.
+    initial(x) <- 0
+    update(x) <- x + v
+  })
+
+  mod <- gen()
+  tt <- 0:20
+  model_set_seed(mod, 1)
+  yy1 <- mod$run(tt)
+
+  model_set_seed(mod, 1)
+  cmp <- model_random_numbers(mod, "normal", length(tt) - 1L)
+  expect_equal(cumsum(c(0, cmp)), yy1[, "x"])
+})
+
+
+test_that("array stochastic variables are time dependent", {
+  ## This checks that even in the absence of array indexing on the RHS
+  ## array variables are set correctly when stochastic.
+  gen <- odin_js({
+    initial(x[]) <- 0
+    update(x[]) <- norm_rand()
+    dim(x) <- 3
+  })
+
+  mod <- gen()
+  tt <- 0:20
+  model_set_seed(mod, 1)
+  yy <- mod$run(tt)
+  ## zz <- mod$transform_variables(yy)
+  zz <- list(x = unname(yy[, 2:4]))
+  model_set_seed(mod, 1)
+  cmp <- rbind(0,
+               matrix(model_random_numbers(mod, "normal", 3 * 20), 20, 3, TRUE))
+  expect_equal(zz$x, cmp)
+})
+
+
+test_that("stochastic initial conditions don't get called every step", {
+  ## There is quite a few nasty little conditions that are tested
+  ## here.
+  gen <- odin_js({
+    v <- norm_rand() # this variable is implicitly time dependent.
+    initial(x) <- v
+    update(x) <- x + 1
+  })
+
+  ## cmp <- .Random.seed
+  mod <- gen()
+  ## expect_equal(.Random.seed, cmp)
+
+  ## Initial conditions (why is $init even a member here?)
+  ## expect_null(mod$init)
+
+  ## Re-running the initial conditions gives different answers:
+  x0 <- mod$initial(0L)
+  ## expect_false(identical(.Random.seed, cmp))
+  expect_true(mod$initial(0L) != x0)
+
+  ## Run the model from scratch
+  tt <- 0:20
+  model_set_seed(mod, 1)
+  yy1 <- mod$run(tt)
+  z <- model_random_numbers(mod, "normal", 1)
+
+  ## First number drawn from distribution, leaving RNG moved forward
+  ## by a single normal draw:
+  model_set_seed(mod, 1)
+  cmp <- model_random_numbers(mod, "normal", 2)
+  expect_equal(yy1[, "x"], cmp[[1]] + tt)
+  expect_equal(z, cmp[[2]])
+
+  ## Don't advance the seed if not hitting the initial conditions.
+  ## cmp <- .Random.seed
+  ## expect_equal(mod$run(tt, 0)[, "x"], as.numeric(0:20))
+  ## expect_equal(mod$run(tt, 1)[, "x"], as.numeric(1:21))
+  ## expect_equal(.Random.seed, cmp)
+})
+
+
+test_that("exotic stochastic functions", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(x) <- 0
+    mu <- 1
+    sd <- 2
+    update(x) <- rnorm(mu, sd)
+  })
+
+  model_set_seed(mod, 1)
+  mod <- gen()
+  y <- mod$run(0:10)
+
+  model_set_seed(mod, 1)
+  expect_equal(y[-1, "x"], rnorm(10, 1, 2))
+})
+
+
+test_that("round & rbinom", {
+  skip("WIP")
+  gen <- odin_js({
+    size <- user()
+    p <- user()
+    update(x) <- 0
+    initial(x) <- rbinom(size, p)
+  })
+
+  mod <- gen(p = 1, size = 0.4)
+  expect_equal(mod$initial(0), 0)
+  mod$set_user(p = 1, size = 1.7)
+  expect_equal(mod$initial(0), 2)
+})
+
+
+test_that("mutlinomial", {
+  skip("WIP")
+  ## This is just a check that these compile and run
+  sir1 <- odin_js("stochastic/sir_discrete.R")
+  sir2 <- odin_js("stochastic/sir_discrete_stochastic.R")
+  sir3 <- odin_js("stochastic/sir_discrete_stochastic2.R")
+  sir4 <- odin_js("stochastic/sir_discrete_stochastic_multi.R")
+
+  mod1 <- sir1()
+  mod2 <- sir2()
+  mod3 <- sir3()
+  mod4 <- sir4()
+
+  t <- 0:100
+  y1 <- mod1$run(t)
+  y2 <- mod2$run(t)
+  y3 <- mod3$run(t)
+  y4 <- mod4$run(t)
+
+  ## TODO: these need real tests!  At the moment I just want to
+  ## confirm that they run.
+  expect_true(TRUE)
+})
+
+
+test_that("replicate: scalar", {
+  skip("WIP")
+  ## TODO: this will be a nice version to try and benchmark the dde
+  ## overheads I think...
+  gen <- odin_js({
+    initial(x) <- 0
+    update(x) <- x + norm_rand()
+  })
+  m <- gen()
+  tt <- 0:50
+  res <- m$run(tt, replicate = 100)
+  yy <- m$transform_variables(res)
+  expect_equal(names(yy), c("t", "x"))
+  expect_equal(yy[[1]], tt)
+  expect_equal(dim(yy[[2]]), c(51, 100))
+  expect_equal(yy[[1]], res[, 1, 1])
+  expect_equal(yy[[2]], res[, 2, ])
+})
+
+
+test_that("replicate: array", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(x) <- 0
+    initial(y[]) <- 0
+    update(x) <- x + norm_rand()
+    update(y[]) <- y[i] + norm_rand() / 2
+    dim(y) <- 3
+  })
+  m <- gen()
+
+  tt <- 0:20
+  res <- m$run(tt, replicate = 30)
+  yy <- m$transform_variables(res)
+  expect_equal(names(yy), c("t", "x", "y"))
+  expect_equal(yy[[1]], tt)
+  expect_equal(dim(yy[[2]]), c(21, 30))
+  expect_equal(dim(yy[[3]]), c(21, 3, 30))
+  expect_equal(yy[[1]], res[, 1, 1])
+  expect_equal(yy[[2]], res[, 2, ])
+  expect_equal(yy[[3]], unname(res[, 3:5, ]))
+})
+
+
+test_that("low-level stochastics: norm_rand", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(y) <- 0
+    update(y) <- norm_rand()
+  })
+  m <- gen()
+
+  tt <- 0:10
+  model_set_seed(mod, 1)
+  y <- m$run(tt)[-1, "y"]
+
+  model_set_seed(mod, 1)
+  expect_equal(y, rnorm(10))
+})
+
+
+test_that("low-level stochastics: unif_rand", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(y) <- 0
+    update(y) <- unif_rand()
+  })
+  m <- gen()
+
+  tt <- 0:10
+  model_set_seed(mod, 1)
+  y <- m$run(tt)[-1, "y"]
+
+  model_set_seed(mod, 1)
+  expect_equal(y, runif(10))
+})
+
+
+test_that("low-level stochastics: exp_rand", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(y) <- 0
+    update(y) <- exp_rand()
+  })
+  m <- gen()
+
+  tt <- 0:10
+  model_set_seed(mod, 1)
+  y <- m$run(tt)[-1, "y"]
+
+  model_set_seed(mod, 1)
+  expect_equal(y, rexp(10))
+})
+
+
+test_that("rexp parametrisation", {
+  skip("WIP")
+  gen <- odin_js({
+    initial(y) <- 0
+    update(y) <- rexp(10)
+  })
+  m <- gen()
+
+  tt <- 0:10
+  model_set_seed(mod, 1)
+  y <- m$run(tt)[-1, "y"]
+
+  model_set_seed(mod, 1)
+  expect_equal(y, rexp(10, 10))
+})

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -109,7 +109,6 @@ test_that("stochastic initial conditions don't get called every step", {
 
 
 test_that("exotic stochastic functions", {
-  skip("WIP")
   gen <- odin_js({
     initial(x) <- 0
     mu <- 1
@@ -117,12 +116,12 @@ test_that("exotic stochastic functions", {
     update(x) <- rnorm(mu, sd)
   })
 
-  model_set_seed(mod, 1)
   mod <- gen()
+  model_set_seed(mod, 1)
   y <- mod$run(0:10)
 
   model_set_seed(mod, 1)
-  expect_equal(y[-1, "x"], rnorm(10, 1, 2))
+  expect_equal(y[-1, "x"], model_random_numbers(mod, "normal", 10, 1, 2))
 })
 
 
@@ -138,12 +137,13 @@ test_that("round & rbinom", {
   mod <- gen(p = 1, size = 0.4)
   expect_equal(mod$initial(0), 0)
   mod$set_user(p = 1, size = 1.7)
+  mod <- gen(p = 1, size = 1.7)
   expect_equal(mod$initial(0), 2)
 })
 
 
 test_that("mutlinomial", {
-  skip("WIP")
+  skip("multinomial not supported")
   ## This is just a check that these compile and run
   sir1 <- odin_js("stochastic/sir_discrete.R")
   sir2 <- odin_js("stochastic/sir_discrete_stochastic.R")
@@ -168,7 +168,7 @@ test_that("mutlinomial", {
 
 
 test_that("replicate: scalar", {
-  skip("WIP")
+  skip("replicate not supported")
   ## TODO: this will be a nice version to try and benchmark the dde
   ## overheads I think...
   gen <- odin_js({
@@ -188,7 +188,7 @@ test_that("replicate: scalar", {
 
 
 test_that("replicate: array", {
-  skip("WIP")
+  skip("replicate not supported")
   gen <- odin_js({
     initial(x) <- 0
     initial(y[]) <- 0
@@ -212,7 +212,6 @@ test_that("replicate: array", {
 
 
 test_that("low-level stochastics: norm_rand", {
-  skip("WIP")
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- norm_rand()
@@ -220,16 +219,15 @@ test_that("low-level stochastics: norm_rand", {
   m <- gen()
 
   tt <- 0:10
-  model_set_seed(mod, 1)
+  model_set_seed(m, 1)
   y <- m$run(tt)[-1, "y"]
 
-  model_set_seed(mod, 1)
-  expect_equal(y, rnorm(10))
+  model_set_seed(m, 1)
+  expect_equal(y, model_random_numbers(m, "normal", 10))
 })
 
 
 test_that("low-level stochastics: unif_rand", {
-  skip("WIP")
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- unif_rand()
@@ -237,16 +235,15 @@ test_that("low-level stochastics: unif_rand", {
   m <- gen()
 
   tt <- 0:10
-  model_set_seed(mod, 1)
+  model_set_seed(m, 1)
   y <- m$run(tt)[-1, "y"]
 
-  model_set_seed(mod, 1)
-  expect_equal(y, runif(10))
+  model_set_seed(m, 1)
+  expect_equal(y, model_random_numbers(m, "uniform", 10))
 })
 
 
 test_that("low-level stochastics: exp_rand", {
-  skip("WIP")
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- exp_rand()
@@ -254,16 +251,15 @@ test_that("low-level stochastics: exp_rand", {
   m <- gen()
 
   tt <- 0:10
-  model_set_seed(mod, 1)
+  model_set_seed(m, 1)
   y <- m$run(tt)[-1, "y"]
 
-  model_set_seed(mod, 1)
-  expect_equal(y, rexp(10))
+  model_set_seed(m, 1)
+  expect_equal(y, model_random_numbers(m, "exponential", 10))
 })
 
 
 test_that("rexp parametrisation", {
-  skip("WIP")
   gen <- odin_js({
     initial(y) <- 0
     update(y) <- rexp(10)
@@ -271,9 +267,9 @@ test_that("rexp parametrisation", {
   m <- gen()
 
   tt <- 0:10
-  model_set_seed(mod, 1)
+  model_set_seed(m, 1)
   y <- m$run(tt)[-1, "y"]
 
-  model_set_seed(mod, 1)
-  expect_equal(y, rexp(10, 10))
+  model_set_seed(m, 1)
+  expect_equal(y, model_random_numbers(m, "exponential", 10, 10))
 })

--- a/tests/testthat/test-support-random.R
+++ b/tests/testthat/test-support-random.R
@@ -91,3 +91,18 @@ test_that("uniform", {
     expect_equal(var(res), 1/3, tolerance = 0.01)
   })
 })
+
+
+test_that("set seed", {
+  skip_if_no_random_js()
+  v8 <- V8::v8()
+  v8$eval(package_js("random.js"))
+
+  v8$call("setSeed", "hello")
+  a <- v8$call("random.unifRand")
+  b <- v8$call("random.unifRand")
+
+  v8$call("setSeed", "hello")
+  expect_equal(v8$call("random.unifRand"), a)
+  expect_equal(v8$call("random.unifRand"), b)
+})

--- a/tests/testthat/test-support-random.R
+++ b/tests/testthat/test-support-random.R
@@ -1,0 +1,93 @@
+context("support: random")
+
+test_that("binomial", {
+  test_binomial <- odin_js_test_random("binomial")
+
+  ## known cases:
+  expect_equal(test_binomial(100, c(100, 0)),
+               rep(0, 100))
+  expect_equal(test_binomial(100, c(100, 1)),
+               rep(100, 100))
+
+  ## rough validation of the mean (trying to confirm that we have the
+  ## parameters correct).
+  try_again(10, {
+    res <- test_binomial(10000, c(10, 0.1))
+    expect_equal(mean(res), 1, tolerance = 0.01)
+    expect_equal(var(res), 0.9, tolerance = 0.01)
+  })
+})
+
+
+test_that("exponential", {
+  test_exponential <- odin_js_test_random("exponential")
+  try_again(10, {
+    res <- test_exponential(10000, 0.01)
+    expect_equal(mean(res), 100, tolerance = 0.01)
+    expect_equal(var(res), 10000, tolerance = 0.01)
+  })
+  try_again(10, {
+    res <- test_exponential(10000, 100)
+    expect_equal(mean(res), 0.01, tolerance = 0.01)
+    expect_equal(var(res), 0.0001, tolerance = 0.01)
+  })
+})
+
+
+test_that("geometric", {
+  test_geometric <- odin_js_test_random("geometric")
+  try_again(10, {
+    res <- test_geometric(50000, 0.2)
+    expect_equal(mean(res), 5, tolerance = 0.01)
+    expect_equal(var(res), 20, tolerance = 0.01)
+  })
+})
+
+
+test_that("normal", {
+  test_normal <- odin_js_test_random("normal")
+
+  try_again(10, {
+    res <- test_normal(10000, c(0, 1))
+    expect_equal(mean(res), 0, tolerance = 0.01)
+    expect_equal(var(res), 1, tolerance = 0.01)
+  })
+
+  try_again(10, {
+    res <- test_normal(10000, c(3, 10))
+    expect_equal(mean(res), 3, tolerance = 0.04)
+    expect_equal(var(res), 100, tolerance = 0.01)
+  })
+})
+
+
+test_that("poisson", {
+  test_poisson <- odin_js_test_random("poisson")
+
+  try_again(10, {
+    res <- test_poisson(10000, 1)
+    expect_equal(mean(res), 1, tolerance = 0.01)
+    expect_equal(var(res), 1, tolerance = 0.01)
+  })
+
+  try_again(10, {
+    res <- test_poisson(10000, 3)
+    expect_equal(mean(res), 3, tolerance = 0.01)
+    expect_equal(var(res), 3, tolerance = 0.01)
+  })
+})
+
+
+test_that("uniform", {
+  test_uniform <- odin_js_test_random("uniform")
+
+  res <- test_uniform(1000, c(2, 4))
+  expect_true(all(res >= 2))
+  expect_true(all(res <= 4))
+
+  try_again(10, {
+    res <- test_uniform(10000, c(2, 4))
+    expect_equal(mean(res), 3, tolerance = 0.01)
+    expect_equal(var(res), 1/3, tolerance = 0.01)
+  })
+})


### PR DESCRIPTION
This PR adds support for stochastic and discrete models. The stochastic support is pretty poor at the moment, but we can expand that later if needed. Importantly it does include the binomial, which is the only random function used in the full version of squire or sircovid. The vast majority of the PR is including a browserified random.js - at some point I'll sort out minifying that and dopri.js

There's a little function `iterateOdin` which iterates a discrete time system.  This is exactly the same book-keeping as in `dde`, which odin uses for discrete time models, and is surprisingly awful to get right.

As before, tests are copied over with minor modification from odin