### PR TITLE
mrc-1498: interface improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.6
+Version: 0.1.7
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonlite,
     odin (>= 0.2.0)
 Suggests:
+    cinterpolate,
     deSolve,
     testthat
 RoxygenNote: 6.1.1

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -235,7 +235,15 @@ generate_js_core_metadata <- function(eqs, dat, rewrite) {
   }
 
   len_block <- function(location) {
-    contents <- dat$data$elements[names(dat$data[[location]]$contents)]
+    if (location == "internal") {
+      ## This excludes interpolate_data and ring_buffer
+      keep <- vlapply(dat$data$elements, function(x)
+        x$location == "internal" &&
+        x$storage_type %in% c("double", "int", "bool"))
+      contents <- dat$data$elements[keep]
+    } else {
+      contents <- dat$data$elements[names(dat$data[[location]]$contents)]
+    }
     if (length(contents) == 0) {
       sprintf("this.metadata.%sOrder = null;", location)
     } else {
@@ -245,7 +253,10 @@ generate_js_core_metadata <- function(eqs, dat, rewrite) {
     }
   }
 
-  body <- c(body, len_block("variable"), len_block("output"))
+  body <- c(body,
+            len_block("internal"),
+            len_block("variable"),
+            len_block("output"))
 
   js_function(NULL, body)
 }

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -24,6 +24,7 @@ generate_js <- function(ir, options) {
   ## This is all we need to dump out
   list(code = generate_js_generator(core, dat),
        name = dat$config$base,
+       ir = ir,
        features = dat$features,
        include = c(interpolate.js = dat$features$has_interpolate,
                    random.js = dat$features$has_stochastic,

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -24,7 +24,7 @@ generate_js <- function(ir, options) {
   ## This is all we need to dump out
   list(code = generate_js_generator(core, dat),
        name = dat$config$base,
-       discrete = dat$features$discrete,
+       features = dat$features,
        include = c(interpolate.js = dat$features$has_interpolate,
                    random.js = dat$features$has_stochastic,
                    discrete.js = dat$features$discrete,
@@ -65,16 +65,17 @@ generate_js_core_create <- function(eqs, dat, rewrite) {
 
 generate_js_core_set_user <- function(eqs, dat, rewrite) {
   update_metadata <- "this.updateMetadata();"
+  allowed <- paste(dquote(names(dat$user)), collapse = ", ")
+  check_user <- sprintf("checkUser(%s, [%s], unusedUserAction);",
+                        dat$meta$user, allowed)
   if (dat$features$has_user) {
-    allowed <- paste(dquote(names(dat$user)), collapse = ", ")
     body <- c(
-      sprintf("checkUser(%s, [%s], unusedUserAction);",
-              dat$meta$user, allowed),
+      check_user,
       sprintf("var %s = this.%s;", dat$meta$internal, dat$meta$internal),
       js_flatten_eqs(eqs[dat$components$user$equations]),
       update_metadata)
   } else {
-    body <- update_metadata
+    body <- c(check_user, update_metadata)
   }
   args <- c(dat$meta$user, "unusedUserAction")
   js_function(args, body)

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -57,8 +57,8 @@ generate_js_core_create <- function(eqs, dat, rewrite) {
   body$add("this.%s = {};", dat$meta$internal)
   body$add("var %s = this.%s;", dat$meta$internal, dat$meta$internal)
   body$add(js_flatten_eqs(eqs[dat$components$create$equations]))
-  body$add("this.setUser(%s);", dat$meta$user)
-  args <- dat$meta$user
+  body$add("this.setUser(%s, unusedUserAction);", dat$meta$user)
+  args <- c(dat$meta$user, "unusedUserAction")
   js_function(args, body$get(), dat$config$base)
 }
 
@@ -66,14 +66,17 @@ generate_js_core_create <- function(eqs, dat, rewrite) {
 generate_js_core_set_user <- function(eqs, dat, rewrite) {
   update_metadata <- "this.updateMetadata();"
   if (dat$features$has_user) {
+    allowed <- paste(dquote(names(dat$user)), collapse = ", ")
     body <- c(
+      sprintf("checkUser(%s, [%s], unusedUserAction);",
+              dat$meta$user, allowed),
       sprintf("var %s = this.%s;", dat$meta$internal, dat$meta$internal),
       js_flatten_eqs(eqs[dat$components$user$equations]),
       update_metadata)
   } else {
     body <- update_metadata
   }
-  args <- dat$meta$user
+  args <- c(dat$meta$user, "unusedUserAction")
   js_function(args, body)
 }
 

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -10,6 +10,8 @@ generate_js_sexp <- function(x, data, meta) {
     } else if (fn == "[") {
       pos <- js_array_access(args[[1L]], args[-1], data, meta)
       ret <- sprintf("%s[%s]", values[[1L]], pos)
+    } else if (fn == "^") {
+      ret <- sprintf("Math.pow(%s, %s)", values[[1]], values[[2]])
     } else if (n == 2L && fn %in% odin:::FUNCTIONS_INFIX) {
       ret <- sprintf("%s %s %s", values[[1]], fn, values[[2]])
     } else if (fn == "if") {
@@ -26,6 +28,8 @@ generate_js_sexp <- function(x, data, meta) {
     } else if (fn == "dim") {
       dim <- data$elements[[args[[1L]]]]$dimnames$dim[[args[[2]]]]
       ret <- generate_js_sexp(dim, data, meta)
+    } else if (fn == "min" || fn == "max") {
+      ret <- js_fold_call(paste0("Math.", fn), values)
     } else if (fn == "sum" || fn == "odin_sum") {
       ret <- generate_js_sexp_sum(args, data, meta)
     } else if (any(names(FUNCTIONS_STOCHASTIC) == fn)) {

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -28,6 +28,9 @@ generate_js_sexp <- function(x, data, meta) {
     } else if (fn == "dim") {
       dim <- data$elements[[args[[1L]]]]$dimnames$dim[[args[[2]]]]
       ret <- generate_js_sexp(dim, data, meta)
+    } else if (fn == "log" && length(values) == 2L) {
+      ret <- sprintf("(Math.log(%s) / Math.log(%s))",
+                     values[[1L]], values[[2L]])
     } else if (fn == "min" || fn == "max") {
       ret <- js_fold_call(paste0("Math.", fn), values)
     } else if (fn == "sum" || fn == "odin_sum") {

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -40,7 +40,9 @@ generate_js_sexp <- function(x, data, meta) {
                      FUNCTIONS_STOCHASTIC[[fn]],
                      paste(values, collapse = ", "))
     } else {
-      if (any(FUNCTIONS_MATH == fn)) {
+      if (any(names(FUNCTIONS_RENAME) == fn)) {
+        fn <- FUNCTIONS_RENAME[[fn]]
+      } else if (any(FUNCTIONS_MATH == fn)) {
         fn <- sprintf("Math.%s", fn)
       } else if (any(names(FUNCTIONS_STOCHASTIC_SPECIAL) == fn)) {
         fn <- sprintf("random.%s", FUNCTIONS_STOCHASTIC_SPECIAL[[fn]])
@@ -89,8 +91,10 @@ generate_js_sexp_sum <- function(args, data, meta) {
 
 FUNCTIONS_RENAME <- c(
   "^" = "Math.pow",
-  ceiling = "Math.ceil"
-)
+  ceiling = "Math.ceil",
+  round = "round2",
+  "%%" = "modr",
+  "%/%" = "intdivr")
 
 
 FUNCTIONS_MATH <- c(
@@ -100,7 +104,7 @@ FUNCTIONS_MATH <- c(
   "acos", "asin", "atan", "atan2",
   "cosh", "sinh", "tanh",
   "acosh", "asinh", "atanh",
-  "abs", "floor", "round", "trunc")
+  "abs", "floor", "trunc")
 
 
 FUNCTIONS_STOCHASTIC_SPECIAL <- c(

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -14,6 +14,8 @@ generate_js_sexp <- function(x, data, meta) {
       ret <- sprintf("Math.pow(%s, %s)", values[[1]], values[[2]])
     } else if (n == 2L && fn %in% odin:::FUNCTIONS_INFIX) {
       ret <- sprintf("%s %s %s", values[[1]], fn, values[[2]])
+    } else if (n == 1L && fn == "-") {
+      ret <- sprintf("- %s", values[[1]])
     } else if (fn == "if") {
       ## NOTE: The ternary operator has very low precendence, so I'm
       ## going to agressively parenthesise it.  This is strictly not
@@ -46,10 +48,9 @@ generate_js_sexp <- function(x, data, meta) {
         fn <- sprintf("Math.%s", fn)
       } else if (any(names(FUNCTIONS_STOCHASTIC_SPECIAL) == fn)) {
         fn <- sprintf("random.%s", FUNCTIONS_STOCHASTIC_SPECIAL[[fn]])
+      } else {
+        stop(sprintf("unsupported function '%s'", fn))
       }
-      ## if (!any(names(FUNCTIONS) == fn)) {
-      ##   stop(sprintf("unsupported function '%s' [odin bug]", fn)) # nocov
-      ## }
       ret <- sprintf("%s(%s)", fn, paste(values, collapse = ", "))
     }
     ret

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ vlapply <- function(X, FUN, ...) {
 
 
 to_json <- function(x, auto_unbox = FALSE, digits = NA, ...) {
-  V8::JS(jsonlite::toJSON(x, auto_unbox = auto_unbox, digits = NA, ...))
+  V8::JS(jsonlite::toJSON(x, auto_unbox = auto_unbox, digits = digits, ...))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,8 +13,8 @@ vlapply <- function(X, FUN, ...) {
 }
 
 
-to_json <- function(x, auto_unbox = FALSE) {
-  V8::JS(jsonlite::toJSON(x, auto_unbox = auto_unbox, digits = NA))
+to_json <- function(x, auto_unbox = FALSE, digits = NA, ...) {
+  V8::JS(jsonlite::toJSON(x, auto_unbox = auto_unbox, digits = NA, ...))
 }
 
 

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -7,7 +7,7 @@ odin_js_wrapper <- function(ir, options) {
   name <- res$name
 
   ret <- function(..., user = list(...), unused_user_action = NULL) {
-    R6_odin_js_wrapper$new(context, name, user, res$features,
+    R6_odin_js_wrapper$new(context, name, user, res$features, res$ir,
                            unused_user_action)
   }
   attr(ret, "ir") <- ir
@@ -64,7 +64,7 @@ R6_odin_js_wrapper <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(context, generator, user, features,
+    initialize = function(context, generator, user, features, ir,
                           unused_user_action) {
       private$context <- context
       private$name <- sprintf("%s.%s", JS_INSTANCES, basename(tempfile("i")))
@@ -90,6 +90,9 @@ R6_odin_js_wrapper <- R6::R6Class(
       }
       private$context$eval(init)
       private$update_metadata()
+
+      self$ir <- ir
+      lockBinding("ir", self)
       lockEnvironment(self)
     },
 

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -41,9 +41,18 @@ R6_odin_js_wrapper <- R6::R6Class(
   private = list(
     context = NULL,
     name = NULL,
+    variable_order = NULL,
+    output_order = NULL,
 
     finalize = function() {
       private$context$eval(sprintf("delete %s;", private$name))
+    },
+
+    update_metadata = function() {
+      private$variable_order <-
+        private$context$get(sprintf("%s.metadata.variableOrder", private$name))
+      private$output_order <-
+        private$context$get(sprintf("%s.metadata.outputOrder", private$name))
     }
   ),
 
@@ -60,6 +69,7 @@ R6_odin_js_wrapper <- R6::R6Class(
         self$deriv <- self$rhs
       }
       private$context$eval(init)
+      private$update_metadata()
       lockEnvironment(self)
     },
 
@@ -71,6 +81,7 @@ R6_odin_js_wrapper <- R6::R6Class(
     set_user = function(user) {
       user_js <- to_json_user(user)
       private$context$call(sprintf("%s.setUser", private$name), user_js)
+      private$update_metadata()
     },
 
     rhs = function(t, y) {
@@ -110,6 +121,10 @@ R6_odin_js_wrapper <- R6::R6Class(
         colnames(res$y) <- res$names
       }
       res$y
+    },
+
+    transform_variables = function(y) {
+      odin:::support_transform_variables(y, private)
     }
   ))
 

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -18,7 +18,9 @@ odin_js_wrapper <- function(ir, options) {
 
 to_json_user <- function(user) {
   f <- function(x) {
-    if (is.array(x)) {
+    if (inherits(x, "JS_EVAL")) {
+      class(x) <- "json"
+    } else if (is.array(x)) {
       x <- list(data = c(x), dim = I(dim(x)))
     } else if (length(x) > 1L || inherits(x, "AsIs")) {
       x <- list(data = x, dim = I(length(x)))
@@ -29,7 +31,7 @@ to_json_user <- function(user) {
     stopifnot(!is.null(names(user)))
   }
   user <- lapply(user, f)
-  to_json(user, auto_unbox = TRUE)
+  to_json(user, auto_unbox = TRUE, json_verbatim = TRUE)
 }
 
 

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -41,6 +41,7 @@ R6_odin_js_wrapper <- R6::R6Class(
   private = list(
     context = NULL,
     name = NULL,
+    internal_order = NULL,
     variable_order = NULL,
     output_order = NULL,
 
@@ -49,6 +50,8 @@ R6_odin_js_wrapper <- R6::R6Class(
     },
 
     update_metadata = function() {
+      private$internal_order <-
+        private$context$get(sprintf("%s.metadata.internalOrder", private$name))
       private$variable_order <-
         private$context$get(sprintf("%s.metadata.variableOrder", private$name))
       private$output_order <-
@@ -99,7 +102,15 @@ R6_odin_js_wrapper <- R6::R6Class(
     },
 
     contents = function() {
-      private$context$get(sprintf("%s.internal", private$name))
+      ret <- private$context$get(sprintf("%s.internal", private$name))
+      order <- private$internal_order
+      for (i in names(ret)) {
+        d <- order[[i]]
+        if (length(d) > 1) {
+          dim(ret[[i]]) <- d
+        }
+      }
+      ret
     },
 
     run = function(t, y = NULL, ..., tcrit = NULL, use_names = TRUE) {

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -81,7 +81,7 @@ R6_odin_js_wrapper <- R6::R6Class(
       private$context$call(sprintf("%s.initial", private$name), t_js)
     },
 
-    set_user = function(user) {
+    set_user = function(..., user = list(...)) {
       user_js <- to_json_user(user)
       private$context$call(sprintf("%s.setUser", private$name), user_js)
       private$update_metadata()

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,7 +70,6 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 ### Limitations and differences
 
 * Solver does not accept an error tolerance
-* Errors have a custom class due to V8, which adds noise to testing
 * the `$initial()` method always requires a time
 * The `use_dde` option to the constructor has gone
 * The `verbose` and `compiler_errors` option to the compiler have gone

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,6 +1,6 @@
 ## odin.js
 
-[![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Travis-CI Build Status](https://travis-ci.org/mrc-ide/odin.js.svg?branch=master)](https://travis-ci.org/mrc-ide/odin.js)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/7o66jpuibiy6havb?svg=true)](https://ci.appveyor.com/project/richfitz/odin-js)
 [![codecov.io](https://codecov.io/github/mrc-ide/odin.js/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/odin.js?branch=master)

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,6 +67,17 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 - [x] discrete models
 - [x] stochastic models
 
+### Limitations and differences
+
+* Solver does not accept an error tolerance
+* Errors have a custom class due to V8, which adds noise to testing
+* the `$initial()` method always requires a time
+* The `use_dde` option to the constructor has gone
+* The `verbose` and `compiler_errors` option to the compiler have gone
+* Minor error message changes
+* Argument names are required for the constructor
+* Stochastic interface does not use R's RNG so results are different and seed setting is not obvious
+
 ---
 
 Please note that the 'odin.js' project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 ### Limitations and differences
 
 * Solver does not accept an error tolerance
-* Errors have a custom class due to V8, which adds noise to testing
 * the `$initial()` method always requires a time
 * The `use_dde` option to the constructor has gone
 * The `verbose` and `compiler_errors` option to the compiler have gone

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## odin.js
 
-[![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Travis-CI Build Status](https://travis-ci.org/mrc-ide/odin.js.svg?branch=master)](https://travis-ci.org/mrc-ide/odin.js)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/7o66jpuibiy6havb?svg=true)](https://ci.appveyor.com/project/richfitz/odin-js)
 [![codecov.io](https://codecov.io/github/mrc-ide/odin.js/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/odin.js?branch=master)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ Chrome will not let you execute js directly off disk (though I think Firefox doe
 - [x] discrete models
 - [x] stochastic models
 
+### Limitations and differences
+
+* Solver does not accept an error tolerance
+* Errors have a custom class due to V8, which adds noise to testing
+* the `$initial()` method always requires a time
+* The `use_dde` option to the constructor has gone
+* The `verbose` and `compiler_errors` option to the compiler have gone
+* Minor error message changes
+* Argument names are required for the constructor
+* Stochastic interface does not use R's RNG so results are different and seed setting is not obvious
+
 ---
 
 Please note that the 'odin.js' project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.

--- a/inst/interpolate.js
+++ b/inst/interpolate.js
@@ -55,7 +55,7 @@ function interpolateAlloc(type, x, y, failOnExtrapolate) {
         y = [];
         for (var i = 0; i < n; ++i) {
             var yi = [];
-            for (j = 0; j < ny; ++j) {
+            for (var j = 0; j < ny; ++j) {
                 yi.push(ylinear[j * n + i]);
             }
             y.push(yi);

--- a/inst/support.js
+++ b/inst/support.js
@@ -302,13 +302,23 @@ function flatten(array, result) {
 }
 
 
-function round2(x, digits) {
-    // TODO: implement proper IEEE rounding here...
-    if (digits === undefined) {
+// https://en.wikipedia.org/wiki/Rounding#Round_half_to_even - same
+// behaviour as R and IEEE 754, with better biases.
+function roundHalfToEven(x) {
+    if (modr(x, 1) === 0.5) {
+        return 2 * Math.round(x / 2);
+    } else {
         return Math.round(x);
+    }
+}
+
+
+function round2(x, digits) {
+    if (digits === undefined) {
+        return roundHalfToEven(x);
     } else {
         var mult = Math.pow(10, digits);
-        return Math.round(x * mult) / mult
+        return roundHalfToEven(x * mult) / mult;
     }
 }
 

--- a/inst/support.js
+++ b/inst/support.js
@@ -195,6 +195,30 @@ function getUserArrayCheckContents(data, min, max, isInteger, name) {
 }
 
 
+function checkUser(user, allowed, unusedUserAction) {
+    if (unusedUserAction === undefined) {
+        unusedUserAction = "stop";
+    }
+    if (unusedUserAction === "ignore") {
+        return;
+    }
+    var err = setDifference(Object.keys(user), allowed);
+    if (err.length > 0) {
+        var msg = "Unknown user parameters: " + err.join(", ");
+
+        if (unusedUserAction === "message") {
+            odinMessage(msg);
+        } else if (unusedUserAction === "warning") {
+            odinWarning(msg);
+        } else if (unusedUserAction === "stop") {
+            throw Error(msg);
+        } else {
+            throw Error(msg + " (and invalid value for unusedUserAction)");
+        }
+    }
+}
+
+
 function isMissing(x) {
     return x === undefined || x === null ||
         (typeof x === "number" && isNaN(x));
@@ -206,6 +230,37 @@ function isMissing(x) {
 // which is close enough to sqrt(double.eps) anyway
 function numberIsInteger(x) {
     return Math.abs(x - Math.round(x)) < 1e-8
+}
+
+
+// O(n^2) but does not use Set, which is not available in old v8
+function setDifference(a, b) {
+  var result = [];
+  for (var i = 0; i < a.length; i++) {
+    if (b.indexOf(a[i]) === -1) {
+      result.push(a[i]);
+    }
+  }
+  return result;
+}
+
+
+// nice behaviour both in and out of R
+function odinWarning(msg) {
+    try {
+        console.r.call("warning", msg)
+    } catch (e) {
+        console.warn(msg)
+    }
+}
+
+
+function odinMessage(msg) {
+    try {
+        console.r.call("message", msg)
+    } catch (e) {
+        console.warn(msg)
+    }
 }
 
 

--- a/inst/support.js
+++ b/inst/support.js
@@ -312,6 +312,20 @@ function round2(x, digits) {
     }
 }
 
+// modulo that conforms to (approximately) the same behaviour as R
+function modr(x, y) {
+    var tmp = x % y;
+    if (tmp * y < 0) {
+        tmp += y;
+    }
+    return tmp;
+}
+
+
+function intdivr(x, y) {
+    return Math.floor(x / y);
+}
+
 
 // Ranks 2..8 created by scripts/create_support_sum_js.R
 function odinSum1(x, from, to) {

--- a/inst/support.js
+++ b/inst/support.js
@@ -287,7 +287,6 @@ function flattenArray(value, name) {
 }
 
 
-// not all js versions have Array.prototype.flat?
 function flatten(array, result) {
   if (array.length === 0) {
     return result

--- a/inst/support.js
+++ b/inst/support.js
@@ -302,6 +302,17 @@ function flatten(array, result) {
 }
 
 
+function round2(x, digits) {
+    // TODO: implement proper IEEE rounding here...
+    if (digits === undefined) {
+        return Math.round(x);
+    } else {
+        var mult = Math.pow(10, digits);
+        return Math.round(x * mult) / mult
+    }
+}
+
+
 // Ranks 2..8 created by scripts/create_support_sum_js.R
 function odinSum1(x, from, to) {
     var tot = 0.0;

--- a/tests/testthat/README.md
+++ b/tests/testthat/README.md
@@ -1,0 +1,11 @@
+The tests odin-run-* are directly ported over from the odin test suite, with some minor changes.  As these changes decrease we may merge this back into the main package.
+
+```
+git diff --no-index odin/tests/testthat/run/test-run-basic.R odin.js/tests/testthat/test-run-basic.R
+git diff --no-index odin/tests/testthat/run/test-run-discrete.R odin.js/tests/testthat/test-run-discrete.R
+git diff --no-index odin/tests/testthat/run/test-run-general.R odin.js/tests/testthat/test-run-general.R
+git diff --no-index odin/tests/testthat/run/test-run-library.R odin.js/tests/testthat/test-run-library.R
+git diff --no-index odin/tests/testthat/run/test-run-interpolation.R odin.js/tests/testthat/test-run-interpolation.R
+git diff --no-index odin/tests/testthat/run/test-run-regression.R odin.js/tests/testthat/test-run-regression.R
+git diff --no-index odin/tests/testthat/run/test-run-stochastic.R odin.js/tests/testthat/test-run-stochastic.R
+```

--- a/tests/testthat/helper-compat.R
+++ b/tests/testthat/helper-compat.R
@@ -1,0 +1,20 @@
+odin_target_name <- function(using) {
+  "js"
+}
+
+
+skip_for_target <- function(target, reason = NULL, using = NULL) {
+  if (target == odin_target_name(using)) {
+    if (is.null(reason)) {
+      msg <- sprintf("Engine is %s", target)
+    } else {
+      msg <- sprintf("Engine is %s (%s)", target, reason)
+    }
+    testthat::skip(msg)
+  }
+}
+
+
+skip_for_delay <- function() {
+  skip("needs delay, not yet implemented in odin.js")
+}

--- a/tests/testthat/helper-compat.R
+++ b/tests/testthat/helper-compat.R
@@ -18,3 +18,8 @@ skip_for_target <- function(target, reason = NULL, using = NULL) {
 skip_for_delay <- function() {
   skip("needs delay, not yet implemented in odin.js")
 }
+
+
+ir_deserialise <- function(ir) {
+  odin:::ir_deserialise(ir)
+}

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -110,3 +110,8 @@ with_options <- function(opts, code) {
   on.exit(oo)
   force(code)
 }
+
+
+to_json_columnwise <- function(x) {
+  V8::JS(jsonlite::toJSON(x, matrix = "columnmajor"))
+}

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -103,3 +103,10 @@ model_random_numbers <- function(x, name, n, ...) {
   f <- V8::JS(sprintf("random.%s(%s)", name, paste(c(...), collapse = ", ")))
   ctx$call("repeat", f, n)
 }
+
+
+with_options <- function(opts, code) {
+  oo <- options(opts)
+  on.exit(oo)
+  force(code)
+}

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -49,11 +49,6 @@ odin_js_test_random <- function(name) {
 }
 
 
-expect_js_error <- function(...) {
-  testthat::expect_error(..., class = "std::runtime_error")
-}
-
-
 to_json_max <- function(x) {
   V8::JS(jsonlite::toJSON(x, digits = NA))
 }

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -104,7 +104,7 @@ test_that("user variables", {
                pi * 10 * (1 - 10 / 100))
 
   mod <- gen(r = pi, N0 = exp(1))
-  mod$set_user(NULL)
+  mod$set_user()
   expect_equal(mod$contents()$r, pi)
   expect_equal(mod$contents()$N0, exp(1))
 })

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -88,12 +88,12 @@ test_that("user variables", {
 
   expect_error(gen())
   ## TODO: Some of these errors are not the same as the other engines
-  expect_js_error(gen(user = NULL),
-                  "Expected a value for 'r'", fixed = TRUE)
-  expect_js_error(gen(r = 1:2),
-                  "Expected a numeric value for 'r'")
-  expect_js_error(gen(r = numeric(0)),
-                  "Expected a numeric value for 'r'")
+  expect_error(gen(user = NULL),
+               "Expected a value for 'r'", fixed = TRUE)
+  expect_error(gen(r = 1:2),
+               "Expected a numeric value for 'r'")
+  expect_error(gen(r = numeric(0)),
+               "Expected a numeric value for 'r'")
 
   expect_equal(sort_list(gen(r = pi)$contents()),
                sort_list(list(K = 100, N0 = 1, initial_N = 1, r = pi)))

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -138,3 +138,13 @@ test_that("delay models are not supported", {
     }),
     "Using unsupported features: 'has_delay'")
 })
+
+
+test_that("some R functions are not available", {
+  expect_error(
+    odin_js({
+      deriv(y) <- 1
+      initial(y) <- choose(4, 3)
+    }),
+    "unsupported function 'choose'")
+})

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -110,6 +110,25 @@ test_that("user variables", {
 })
 
 
+test_that("accept matrices directly if asked nicely", {
+  gen <- odin_js({
+    deriv(y) <- 1
+    initial(y) <- 1
+    matrix[,] <- user()
+    dim(matrix) <- user()
+  })
+
+  m <- matrix(1:12, c(3, 4))
+  mod <- gen(matrix = to_json_columnwise(m))
+  expect_equal(
+    mod$contents()$matrix, m)
+
+  mod <- gen(matrix = m)
+  expect_equal(
+    mod$contents()$matrix, m)
+})
+
+
 test_that("delay models are not supported", {
   expect_error(
     odin_js({

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -201,9 +201,9 @@ test_that("copy output", {
   mod <- gen()
   tt <- 0:10
   y <- mod$run(tt)
-  ## yy <- mod$transform_variables(y) # TODO
-  expect_equivalent(y[, 2], tt + 1)
-  expect_equivalent(y[, 3:7], matrix(tt, length(tt), 5))
+  yy <- mod$transform_variables(y)
+  expect_equal(yy$y, tt + 1)
+  expect_equal(yy$z, matrix(tt, length(tt), 5))
 })
 
 
@@ -269,10 +269,10 @@ test_that("array support", {
                           deparse.level = 0))
   expect_equal(colnames(yy), c("t", "y", "x[1]", "x[2]", "x[3]"))
 
-  ## expect_equal(mod$transform_variables(yy),
-  ##              list(t = tt,
-  ##                   y = yy[, 2],
-  ##                   x = unname(yy[, 3:5])))
+  expect_equal(mod$transform_variables(yy),
+               list(t = tt,
+                    y = yy[, 2],
+                    x = unname(yy[, 3:5])))
 })
 
 

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -143,7 +143,7 @@ test_that("user variables", {
                pi * 10 * (1 - 10 / 100))
 
   mod <- gen(r = pi, N0 = exp(1))
-  mod$set_user(NULL)
+  mod$set_user()
   expect_equal(mod$contents()$r, pi)
   expect_equal(mod$contents()$N0, exp(1))
 })

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -124,13 +124,13 @@ test_that("user variables", {
 
   expect_error(gen())
   ## TODO: had to change error strings here
-  expect_js_error(gen(user = NULL),
-                  "Expected a value for 'r'", fixed = TRUE)
-  expect_js_error(gen(r = 1:2),
-                  "Expected a numeric value for 'r'", fixed = TRUE)
-  expect_js_error(gen(r = numeric(0)),
-                  "Expected a numeric value for 'r'",
-                  fixed = TRUE)
+  expect_error(gen(user = NULL),
+               "Expected a value for 'r'", fixed = TRUE)
+  expect_error(gen(r = 1:2),
+               "Expected a numeric value for 'r'", fixed = TRUE)
+  expect_error(gen(r = numeric(0)),
+               "Expected a numeric value for 'r'",
+               fixed = TRUE)
 
   expect_equal(sort_list(gen(r = pi)$contents()),
                sort_list(list(K = 100, N0 = 1, initial_N = 1, r = pi)))
@@ -329,7 +329,7 @@ test_that("user array", {
 
   mod <- gen(r = 1:3)
   expect_equal(mod$contents()$r, 1:3)
-  expect_js_error(gen(r = I(1)), "Expected length 3 value for 'r'")
+  expect_error(gen(r = I(1)), "Expected length 3 value for 'r'")
 })
 
 
@@ -358,12 +358,12 @@ test_that("user matrix", {
     msg2 <- "Incorrect size of dimension 1 of r (expected 2)"
   }
 
-  expect_js_error(gen(r = c(r)), msg1, fixed = TRUE)
-  expect_js_error(gen(r = I(r[2, 2])), msg1, fixed = TRUE)
-  expect_js_error(gen(r = array(1, 2:4)), msg1, fixed = TRUE)
-  expect_js_error(gen(r = I(1)), msg1, fixed = TRUE)
+  expect_error(gen(r = c(r)), msg1, fixed = TRUE)
+  expect_error(gen(r = I(r[2, 2])), msg1, fixed = TRUE)
+  expect_error(gen(r = array(1, 2:4)), msg1, fixed = TRUE)
+  expect_error(gen(r = I(1)), msg1, fixed = TRUE)
 
-  expect_js_error(gen(r = t(r)), msg2, fixed = TRUE)
+  expect_error(gen(r = t(r)), msg2, fixed = TRUE)
 })
 
 
@@ -386,8 +386,8 @@ test_that("user array - indirect", {
                  n = 3,
                  r = 1:3)))
 
-  expect_js_error(gen(n = 4, r = 1:3),
-                  "Expected length 4 value for 'r'")
+  expect_error(gen(n = 4, r = 1:3),
+               "Expected length 4 value for 'r'")
 })
 
 
@@ -404,10 +404,10 @@ test_that("user array - direct", {
   expect_equal(
     sort_list(mod$contents()),
     sort_list(list(dim_r = 3, dim_x = 3, initial_x = rep(1, 3), r = 1:3)))
-  expect_js_error(gen(r = matrix(1, 2, 3)),
-                  "Expected a numeric vector for 'r'")
-  expect_js_error(gen(r = NULL),
-                  "Expected an odin.js array object for 'r'")
+  expect_error(gen(r = matrix(1, 2, 3)),
+               "Expected a numeric vector for 'r'")
+  expect_error(gen(r = NULL),
+               "Expected an odin.js array object for 'r'")
   ## expect_silent(mod$set_user(r = NULL)) # TODO - this differs...
   expect_equal(mod$contents()$r, 1:3)
 })
@@ -428,10 +428,10 @@ test_that("user array - direct 3d", {
                               dim_r_2 = 3, dim_r_3 = 4, initial_y = 1,
                               r = m)))
 
-  expect_js_error(gen(r = I(1)),
-                  "Expected a numeric array of rank 3 for 'r'")
-  expect_js_error(gen(r = matrix(1)),
-                  "Expected a numeric array of rank 3 for 'r'")
+  expect_error(gen(r = I(1)),
+               "Expected a numeric array of rank 3 for 'r'")
+  expect_error(gen(r = matrix(1)),
+               "Expected a numeric array of rank 3 for 'r'")
 })
 
 
@@ -607,12 +607,12 @@ test_that("rich user arrays", {
 
   r <- matrix(runif(6), 2, 3)
   expect_error(gen(r = r), NA)
-  expect_js_error(gen(r = -r), "Expected 'r' to be at least 0")
+  expect_error(gen(r = -r), "Expected 'r' to be at least 0")
   r[5] <- -1
-  expect_js_error(gen(r = r), "Expected 'r' to be at least 0")
+  expect_error(gen(r = r), "Expected 'r' to be at least 0")
   r[5] <- NA
   ## TODO: not a great error
-  expect_js_error(gen(r = r), "Expected a numeric value for 'r'")
+  expect_error(gen(r = r), "Expected a numeric value for 'r'")
 })
 
 
@@ -628,9 +628,9 @@ test_that("rich user sized arrays", {
   r <- matrix(runif(6), 2, 3)
 
   expect_error(gen(r = r), NA)
-  expect_js_error(gen(r = -r), "Expected 'r' to be at least 0")
+  expect_error(gen(r = -r), "Expected 'r' to be at least 0")
   r[5] <- -1
-  expect_js_error(gen(r = r), "Expected 'r' to be at least 0")
+  expect_error(gen(r = r), "Expected 'r' to be at least 0")
 })
 
 

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -299,7 +299,7 @@ test_that("3d array", {
 
   mod <- gen()
   d <- mod$contents()
-  ## expect_equal(d$initial_y, array(1, c(2, 3, 4))) # TODO
+  expect_equal(d$initial_y, array(1, c(2, 3, 4))) # TODO
   expect_equal(d$dim_y, 24)
   expect_equal(d$dim_y_1, 2)
   expect_equal(d$dim_y_2, 3)

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -101,7 +101,7 @@ test_that("2d array equations", {
   mod <- gen(x0 = x0, r = r)
   yy <- mod$run(0:10)
 
-  expect_equal(mod$contents()$x0, c(x0)) # TODO - reshape
+  expect_equal(mod$contents()$x0, x0)
   expect_equal(matrix(mod$initial(0), 2, 5), x0)
 
   expect_equal(unname(diff(yy)[1, ]), c(1, c(r)))

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -56,16 +56,16 @@ test_that("interpolate", {
 
   sp <- c(0, 10, 20)
   zp <- c(0, 1, 0)
-  expect_js_error(gen(sp = sp, zp = zp[1:2]),
-                  "Expected length 3 value for 'zp'")
-  expect_js_error(gen(sp = sp, zp = rep(zp, 2)),
-                  "Expected length 3 value for 'zp'")
+  expect_error(gen(sp = sp, zp = zp[1:2]),
+               "Expected length 3 value for 'zp'")
+  expect_error(gen(sp = sp, zp = rep(zp, 2)),
+               "Expected length 3 value for 'zp'")
 
   mod <- gen(sp = sp, zp = zp)
 
   tt <- 0:30
-  expect_js_error(mod$run(tt - 1L),
-                  "Integration times do not span interpolation")
+  expect_error(mod$run(tt - 1L),
+               "Integration times do not span interpolation")
 
   yy <- mod$run(tt)
   zz <- cumsum(ifelse(tt <= 10 | tt > 20, 0, 1))

--- a/tests/testthat/test-run-discrete.R
+++ b/tests/testthat/test-run-discrete.R
@@ -37,8 +37,7 @@ test_that("output", {
 
   tt <- 0:10
   yy <- mod$run(tt)
-  ## zz <- mod$transform_variables(yy)
-  zz <- list(x = unname(yy[, 2:11]), total = yy[, 12])
+  zz <- mod$transform_variables(yy)
 
   expect_equal(zz$x, t(outer(r, tt) + x0))
   expect_equal(zz$total, rowSums(zz$x))
@@ -133,8 +132,7 @@ test_that("complex initialisation: scalar", {
   model_set_seed(mod, 1)
 
   v <- mod$initial(0)
-  ## vv <- mod$transform_variables(v)
-  vv <- list(x1 = v[[1]], x2 = v[[2]])
+  vv <- mod$transform_variables(v)
 
   ## set.seed(1)
   ## x1 <- rnorm(1)
@@ -175,8 +173,7 @@ test_that("complex initialisation: vector", {
   mod <- gen()
   model_set_seed(mod, 1)
   v <- mod$initial(0)
-  ## vv <- mod$transform_variables(v)
-  vv <- list(x1 = v[1:10], x2 = v[11:20])
+  vv <- mod$transform_variables(v)
 
   model_set_seed(mod, 1)
   ctx <- model_context(mod)

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -706,35 +706,35 @@ test_that("non-numeric input", {
   expect_equal(dat$array4, array4)
 
   ## Then test for errors on each as we convert to character:
-  expect_js_error(
+  expect_error(
     gen(scalar = convert(scalar, "character"),
         vector = vector,
         matrix = matrix,
         array = array,
         array4 = array4),
     "Expected a numeric value for 'scalar'")
-  expect_js_error(
+  expect_error(
     gen(scalar = scalar,
         vector = convert(vector, "character"),
         matrix = matrix,
         array = array,
         array4 = array4),
     "Expected a numeric value for 'vector'")
-  expect_js_error(
+  expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = convert(matrix, "character"),
         array = array,
         array4 = array4),
     "Expected a numeric value for 'matrix'")
-  expect_js_error(
+  expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = matrix,
         array = convert(array, "character"),
         array4 = array4),
     "Expected a numeric value for 'array'")
-  expect_js_error(
+  expect_error(
     gen(scalar = scalar,
         vector = vector,
         matrix = matrix,
@@ -1146,10 +1146,10 @@ test_that("user integer", {
     y0 <- user(1, integer = TRUE, min = 0)
   })
 
-  expect_js_error(gen(y0 = 1.5),
-                  "Expected 'y0' to be integer-like")
-  expect_js_error(gen(y0 = -1L),
-                  "Expected 'y0' to be at least 0")
+  expect_error(gen(y0 = 1.5),
+               "Expected 'y0' to be integer-like")
+  expect_error(gen(y0 = -1L),
+               "Expected 'y0' to be at least 0")
 
   mod <- gen(y0 = 1)
   expect_equal(mod$run(0:10)[, "y"], 1.0 + 0.5 * (0:10))
@@ -1164,8 +1164,8 @@ test_that("multiple constraints", {
     r <- user(0.5, max = 10)
   })
 
-  expect_js_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
-  expect_js_error(gen(r = 100), "Expected 'r' to be at most 10")
+  expect_error(gen(y0 = -1L), "Expected 'y0' to be at least 0")
+  expect_error(gen(r = 100), "Expected 'r' to be at most 10")
 })
 
 
@@ -1178,9 +1178,9 @@ test_that("set_user honours constraints", {
   })
 
   mod <- gen()
-  expect_js_error(mod$set_user(y0 = -1L),
-                  "Expected 'y0' to be at least 0")
-  expect_js_error(mod$set_user(r = 100), "Expected 'r' to be at most 10")
+  expect_error(mod$set_user(y0 = -1L),
+               "Expected 'y0' to be at least 0")
+  expect_error(mod$set_user(r = 100), "Expected 'r' to be at most 10")
 })
 
 
@@ -1207,7 +1207,7 @@ test_that("user parameter validation", {
   })
 
   ## Honour all the options:
-  expect_js_error(
+  expect_error(
     gen(user = list(r = 1, a = 1), unused_user_action = "stop"),
     "Unknown user parameters: a")
   expect_warning(
@@ -1220,7 +1220,7 @@ test_that("user parameter validation", {
     gen(user = list(r = 1, a = 1), unused_user_action = "ignore"))
 
   ## Sensible error message for invalid option
-  expect_js_error(
+  expect_error(
     gen(user = list(r = 1, a = 1), unused_user_action = "other"),
     "Unknown user parameters: a (and invalid value for unusedUserAction)",
     fixed = TRUE)
@@ -1235,7 +1235,7 @@ test_that("user parameter validation", {
   ## Override option
   with_options(
     list(odin.unused_user_action = "message"),
-    expect_js_error(
+    expect_error(
       gen(user = list(r = 1, a = 1), unused_user_action = "error"),
       "Unknown user parameters: a"))
 
@@ -1250,7 +1250,7 @@ test_that("user parameter validation", {
   mod <- gen(r = 1)
   expect_silent(
     mod$set_user(user = list(x = 1), unused_user_action = "ignore"))
-  expect_js_error(
+  expect_error(
     mod$set_user(user = list(x = 1), unused_user_action = "error"),
     "Unknown user parameters: x")
 })

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1022,7 +1022,6 @@ test_that("integer vector", {
   expect_equal(dat$idx, idx)
   expect_equal(dat$initial_v, x[idx])
 
-  skip("interface issue")
   expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
                "int")
 })
@@ -1051,7 +1050,6 @@ test_that("integer matrix", {
   mod <- gen(x = x, idx = idx)
   expect_equal(mod$contents()$v, v)
 
-  skip("interface issue")
   expect_equal(ir_deserialise(mod$ir)$data$elements$idx$storage_type,
                "int")
 })
@@ -1084,8 +1082,7 @@ test_that("user variable information", {
   expect_equal(info$has_default, c(FALSE, TRUE, TRUE))
   expect_equal(info$rank, c(1L, 0L, 0L))
 
-  skip("interface error")
-  expect_identical(coef(gen(1)), info)
+  expect_identical(coef(gen(r = I(1))), info)
 })
 
 
@@ -1107,7 +1104,6 @@ test_that("user variable information - when no user", {
                     integer = logical(),
                     stringsAsFactors = FALSE)
   expect_identical(info, cmp)
-  skip("interface issue")
   expect_identical(coef(gen()), cmp)
 })
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1222,7 +1222,6 @@ test_that("user sized dependent variables are allowed", {
 
 
 test_that("user parameter validation", {
-  skip("user validation")
   gen <- odin_js({
     deriv(y) <- r
     initial(y) <- 1
@@ -1230,7 +1229,7 @@ test_that("user parameter validation", {
   })
 
   ## Honour all the options:
-  expect_error(
+  expect_js_error(
     gen(user = list(r = 1, a = 1), unused_user_action = "stop"),
     "Unknown user parameters: a")
   expect_warning(
@@ -1243,9 +1242,9 @@ test_that("user parameter validation", {
     gen(user = list(r = 1, a = 1), unused_user_action = "ignore"))
 
   ## Sensible error message for invalid option
-  expect_error(
+  expect_js_error(
     gen(user = list(r = 1, a = 1), unused_user_action = "other"),
-    "Unknown user parameters: a (and invalid value for unused_user_action)",
+    "Unknown user parameters: a (and invalid value for unusedUserAction)",
     fixed = TRUE)
 
   ## Inherit action from option
@@ -1258,7 +1257,7 @@ test_that("user parameter validation", {
   ## Override option
   with_options(
     list(odin.unused_user_action = "message"),
-    expect_error(
+    expect_js_error(
       gen(user = list(r = 1, a = 1), unused_user_action = "error"),
       "Unknown user parameters: a"))
 
@@ -1273,7 +1272,7 @@ test_that("user parameter validation", {
   mod <- gen(r = 1)
   expect_silent(
     mod$set_user(user = list(x = 1), unused_user_action = "ignore"))
-  expect_error(
+  expect_js_error(
     mod$set_user(user = list(x = 1), unused_user_action = "error"),
     "Unknown user parameters: x")
 })

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -57,7 +57,6 @@ test_that("user variables", {
 })
 
 test_that("user variables on models with none", {
-  skip("interface issue")
   gen <- odin_js({
     a <- 1
     deriv(y) <- 0.5 * a
@@ -71,7 +70,7 @@ test_that("user variables on models with none", {
 })
 
 test_that("non-numeric time", {
-  skip("needs delay")
+  skip_for_delay()
   ## Only an issue for delay models or models with time-dependent
   ## initial conditions.
   gen <- odin_js({
@@ -86,7 +85,7 @@ test_that("non-numeric time", {
 })
 
 test_that("delays and initial conditions", {
-  skip("needs delay")
+  skip_for_delay()
   gen <- odin_js({
     ylag <- delay(y, 10)
     initial(y) <- 0.5
@@ -216,8 +215,8 @@ test_that("time dependent initial conditions", {
 })
 
 test_that("user c", {
-  skip("not relevant")
   skip_for_target("r")
+  skip_for_target("js")
   gen <- odin_js({
     config(include) <- "user_fns.c"
     z <- squarepulse(t, 1, 2)
@@ -238,8 +237,8 @@ test_that("user c", {
 })
 
 test_that("user c in subdir", {
-  skip("not relevant")
   skip_for_target("r")
+  skip_for_target("js")
   dest <- tempfile()
   dir.create(dest)
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -38,21 +38,21 @@ test_that("user variables", {
   expect_equal(dat$K, 100.0)
 
   ## This should be a noop:
-  mod$set_user(NULL)
+  mod$set_user()
   dat <- mod$contents()
   expect_equal(dat$r, pi)
   expect_equal(dat$N0, 1.0)
   expect_equal(dat$K, 100.0)
 
   ## Now, try setting one of these:
-  mod$set_user(list(N0 = 5)) # TODO: different interface
+  mod$set_user(N0 = 5)
   dat <- mod$contents()
   expect_equal(dat$r, pi)
   expect_equal(dat$N0, 5.0)
   expect_equal(dat$K, 100.0)
 
   ## Don't reset to default on subsequent set:
-  mod$set_user(NULL)
+  mod$set_user()
   expect_equal(mod$contents()$N0, 5.0)
 })
 
@@ -1200,9 +1200,9 @@ test_that("set_user honours constraints", {
   })
 
   mod <- gen()
-  expect_js_error(mod$set_user(list(y0 = -1L)),
+  expect_js_error(mod$set_user(y0 = -1L),
                   "Expected 'y0' to be at least 0")
-  expect_js_error(mod$set_user(list(r = 100)), "Expected 'r' to be at most 10")
+  expect_js_error(mod$set_user(r = 100), "Expected 'r' to be at most 10")
 })
 
 

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -381,9 +381,8 @@ test_that("4d array", {
 
   mod <- gen()
   expect_equal(mod$initial(0), rep(1.0, 2 * 3 * 4 * 5))
-  ## TODO:
-  ## dat <- mod$contents()
-  ## expect_equal(dat$initial_y, array(1, c(2, 3, 4, 5)))
+  dat <- mod$contents()
+  expect_equal(dat$initial_y, array(1, c(2, 3, 4, 5)))
 })
 
 ## I need a system with mixed variables and arrays for testing the
@@ -512,7 +511,7 @@ test_that("use dim on rhs", {
 
   mod <- gen()
   expect_equal(mod$contents()$r, rep(0.1, 3))
-  expect_equal(mod$contents()$initial_y, rep(1, 3 * 4)) # TODO: return matrix
+  expect_equal(mod$contents()$initial_y, matrix(1, 3, 4))
 })
 
 
@@ -696,10 +695,9 @@ test_that("non-numeric input", {
 
   expect_equal(dat$scalar, scalar)
   expect_equal(dat$vector, vector)
-  ## TODO: should shape these back on return
-  expect_equal(dat$matrix, c(matrix))
-  expect_equal(dat$array,  c(array))
-  expect_equal(dat$array4, c(array4))
+  expect_equal(dat$matrix, matrix)
+  expect_equal(dat$array,  array)
+  expect_equal(dat$array4, array4)
 
   ## Then to integer first:
   mod <- gen(scalar = convert(scalar),
@@ -711,9 +709,9 @@ test_that("non-numeric input", {
   expect_equal(dat$scalar, scalar)
   expect_equal(dat$vector, vector)
   ## TODO: should shape these back on return
-  expect_equal(dat$matrix, c(matrix))
-  expect_equal(dat$array,  c(array))
-  expect_equal(dat$array4, c(array4))
+  expect_equal(dat$matrix, matrix)
+  expect_equal(dat$array,  array)
+  expect_equal(dat$array4, array4)
 
   ## Then test for errors on each as we convert to character:
   expect_error(
@@ -835,7 +833,7 @@ test_that("sum over one dimension", {
   m <- matrix(runif(nr * nc), nr, nc)
   dat <- gen(m = m)$contents()
 
-  expect_equal(dat$m, c(m)) # TODO: reshape
+  expect_equal(dat$m, m)
   expect_equal(dat$v1, rowSums(m))
   expect_equal(dat$v2, colSums(m))
 
@@ -897,18 +895,18 @@ test_that("sum over two dimensions", {
   a <- array(runif(nr * nc * nz), c(nr, nc, nz))
   dat <- gen(a = a)$contents()
 
-  expect_equal(dat$a, c(a)) # TODO: reshaping all through here
-  expect_equal(dat$m12, c(apply(a, 1:2, sum)))
-  expect_equal(dat$m13, c(apply(a, c(1, 3), sum)))
-  expect_equal(dat$m23, c(apply(a, 2:3, sum)))
+  expect_equal(dat$a, a)
+  expect_equal(dat$m12, apply(a, 1:2, sum))
+  expect_equal(dat$m13, apply(a, c(1, 3), sum))
+  expect_equal(dat$m23, apply(a, 2:3, sum))
 
   expect_equal(dat$v1, apply(a, 1, sum))
   expect_equal(dat$v2, apply(a, 2, sum))
   expect_equal(dat$v3, apply(a, 3, sum))
 
-  expect_equal(dat$mm12, c(apply(a[,,2:4], 1:2, sum)))
-  expect_equal(dat$mm13, c(apply(a[,2:4,], c(1, 3), sum)))
-  expect_equal(dat$mm23, c(apply(a[2:4,,], 2:3, sum)))
+  expect_equal(dat$mm12, apply(a[,,2:4], 1:2, sum))
+  expect_equal(dat$mm13, apply(a[,2:4,], c(1, 3), sum))
+  expect_equal(dat$mm23, apply(a[2:4,,], 2:3, sum))
 
   expect_equal(dat$vv1, apply(a[,2:4,2:4], 1, sum))
   expect_equal(dat$vv2, apply(a[2:4,,2:4], 2, sum))
@@ -945,10 +943,10 @@ test_that("sum for a 4d array", {
   a <- array(runif(prod(dim)), dim)
   dat <- gen(a = a)$contents()
 
-  expect_equal(dat$a, c(a))
-  expect_equal(dat$m12, c(apply(a, 1:2, sum)))
-  expect_equal(dat$m23, c(apply(a, c(2, 3), sum)))
-  expect_equal(dat$m24, c(apply(a, c(2, 4), sum)))
+  expect_equal(dat$a, a)
+  expect_equal(dat$m12, apply(a, 1:2, sum))
+  expect_equal(dat$m23, apply(a, c(2, 3), sum))
+  expect_equal(dat$m24, apply(a, c(2, 4), sum))
 })
 
 test_that("self output for scalar", {

--- a/tests/testthat/test-run-interpolation.R
+++ b/tests/testthat/test-run-interpolation.R
@@ -29,14 +29,14 @@ test_that("constant", {
   ## already some checking there.
   tp <- c(0, 1, 2)
   zp <- c(0, 1, 0)
-  expect_js_error(gen(tp = tp, zp = zp[1:2]), "Expected zp to have length 3")
-  expect_js_error(gen(tp = tp, zp = rep(zp, 2)), "Expected zp to have length 3")
+  expect_error(gen(tp = tp, zp = zp[1:2]), "Expected zp to have length 3")
+  expect_error(gen(tp = tp, zp = rep(zp, 2)), "Expected zp to have length 3")
 
   mod <- gen(tp = tp, zp = zp)
 
   tt <- seq(0, 3, length.out = 301)
-  expect_js_error(mod$run(tt - 0.1),
-                  "Integration times do not span interpolation")
+  expect_error(mod$run(tt - 0.1),
+               "Integration times do not span interpolation")
 
   yy <- mod$run(tt)
   zz <- ifelse(tt < 1, 0, ifelse(tt > 2, 1, tt - 1))
@@ -63,16 +63,16 @@ test_that("constant array", {
   zp <- cbind(c(0, 1, 0),
               c(0, 2, 0))
   ## Two dimensions to check here:
-  expect_js_error(gen(tp = tp, zp = zp[1:2, ]), "zp to have size 3")
-  expect_js_error(gen(tp = tp, zp = zp[c(1:3, 1:3), ]), "zp to have size 3")
-  expect_js_error(gen(tp = tp, zp = zp[, 1, drop = FALSE]), "zp to have size 2")
-  expect_js_error(gen(tp = tp, zp = zp[, c(1:2, 1)]), "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[1:2, ]), "zp to have size 3")
+  expect_error(gen(tp = tp, zp = zp[c(1:3, 1:3), ]), "zp to have size 3")
+  expect_error(gen(tp = tp, zp = zp[, 1, drop = FALSE]), "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[, c(1:2, 1)]), "zp to have size 2")
 
   mod <- gen(tp = tp, zp = zp)
 
   tt <- seq(0, 3, length.out = 301)
-  expect_js_error(mod$run(tt - 0.1),
-                  "Integration times do not span interpolation")
+  expect_error(mod$run(tt - 0.1),
+               "Integration times do not span interpolation")
 
   yy <- mod$run(tt)
   zz1 <- ifelse(tt < 1, 0, ifelse(tt > 2, 1, tt - 1))
@@ -111,20 +111,20 @@ test_that("constant 3d array", {
   stopifnot(isTRUE(all.equal(zp[3,,], matrix(0, 2, 2))))
 
   ## Three dimensions to check here:
-  expect_js_error(gen(tp = tp, zp = zp[1:2, , ]), "zp to have size 3")
-  expect_js_error(gen(tp = tp, zp = zp[c(1:3, 1:3), , ]), "zp to have size 3")
-  expect_js_error(gen(tp = tp, zp = zp[, 1, , drop = FALSE]),
-                  "zp to have size 2")
-  expect_js_error(gen(tp = tp, zp = zp[, c(1:2, 1), ]), "zp to have size 2")
-  expect_js_error(gen(tp = tp, zp = zp[, , 1, drop = FALSE]),
-                  "zp to have size 2")
-  expect_js_error(gen(tp = tp, zp = zp[, , c(1:2, 1)]), "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[1:2, , ]), "zp to have size 3")
+  expect_error(gen(tp = tp, zp = zp[c(1:3, 1:3), , ]), "zp to have size 3")
+  expect_error(gen(tp = tp, zp = zp[, 1, , drop = FALSE]),
+               "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[, c(1:2, 1), ]), "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[, , 1, drop = FALSE]),
+               "zp to have size 2")
+  expect_error(gen(tp = tp, zp = zp[, , c(1:2, 1)]), "zp to have size 2")
 
   mod <- gen(tp = tp, zp = zp)
 
   tt <- seq(0, 3, length.out = 301)
-  expect_js_error(mod$run(tt - 0.1),
-                  "Integration times do not span interpolation")
+  expect_error(mod$run(tt - 0.1),
+               "Integration times do not span interpolation")
 
   yy <- mod$run(tt)
   cmp <- sapply(1:4, function(i)
@@ -158,11 +158,11 @@ test_that("linear", {
   cmp <- deSolve::lsoda(mod$initial(0), tt, target, tcrit = 2)
   expect_equal(yy[, 2], cmp[, 2], tolerance = 1e-5)
 
-  expect_js_error(mod$run(c(tt, max(tp) + 1)),
-                  "Integration times do not span interpolation range")
+  expect_error(mod$run(c(tt, max(tp) + 1)),
+               "Integration times do not span interpolation range")
 
-  expect_js_error(mod$run(tt, tcrit = 10),
-                  "Interpolation failed as .+ is out of range")
+  expect_error(mod$run(tt, tcrit = 10),
+               "Interpolation failed as .+ is out of range")
 })
 
 
@@ -242,10 +242,10 @@ test_that("interpolation with two variables", {
     cmp <- deSolve::lsoda(0, tt, deriv, p, tcrit = t1)
     expect_equal(res[, 2], cmp[, 2], tolerance = 1e-4)
 
-    expect_js_error(mod$run(tt + 1),
-                    "Integration times do not span interpolation range")
-    expect_js_error(mod$run(tt - 1),
-                    "Integration times do not span interpolation range")
+    expect_error(mod$run(tt + 1),
+                 "Integration times do not span interpolation range")
+    expect_error(mod$run(tt - 1),
+                 "Integration times do not span interpolation range")
   }
 })
 
@@ -437,9 +437,9 @@ test_that("double delayed interpolation function", {
 
   expect_equal(yy[, "udd"], ifelse(tt < 5, 0, 0.5))
 
-  expect_js_error(gen(ut = c(0, 2), uy = uy)$run(tt),
-                  "Interpolation failed as -2.* is out of range")
-  expect_js_error(gen(ut = c(-2, 2), uy = uy)$run(tt),
-                  "Interpolation failed as -3.* is out of range")
+  expect_error(gen(ut = c(0, 2), uy = uy)$run(tt),
+               "Interpolation failed as -2.* is out of range")
+  expect_error(gen(ut = c(-2, 2), uy = uy)$run(tt),
+               "Interpolation failed as -3.* is out of range")
   expect_equal(gen(ut = c(-3, 2), uy = uy)$run(tt), yy)
 })

--- a/tests/testthat/test-run-interpolation.R
+++ b/tests/testthat/test-run-interpolation.R
@@ -251,7 +251,7 @@ test_that("interpolation with two variables", {
 
 
 test_that("interpolation in a delay", {
-  skip("not yet supported")
+  skip_for_delay()
   gen <- odin_js({
     deriv(y) <- ud
     initial(y) <- 0
@@ -281,7 +281,7 @@ test_that("interpolation in a delay", {
 
 
 test_that("interpolation in a delay, with default", {
-  skip("not yet supported")
+  skip_for_delay()
   gen <- odin_js({
     deriv(y) <- ud
     initial(y) <- 0
@@ -311,9 +311,9 @@ test_that("interpolation in a delay, with default", {
 
 
 test_that("critical times", {
-  skip("not yet supported")
   ## this is only done for the R generation so far:
   skip_for_target("c")
+  skip_for_target("js", "mulitple critical times")
   gen <- odin_js({
     deriv(y) <- pulse1 + pulse2
     initial(y) <- 0
@@ -405,7 +405,7 @@ test_that("user sized interpolation, 2d", {
 
 
 test_that("double delayed interpolation function", {
-  skip("not yet supported")
+  skip_for_delay()
   gen <- odin_js({
     deriv(y) <- ud
     initial(y) <- 0

--- a/tests/testthat/test-run-library.R
+++ b/tests/testthat/test-run-library.R
@@ -1,0 +1,145 @@
+context("run: library support")
+
+test_that("abs", {
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 0
+    output(a) <- abs(t)
+  })
+  tt <- seq(-5, 5, length.out = 101)
+  expect_equal(gen()$run(tt)[, "a"], abs(tt))
+})
+
+
+test_that("log", {
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 0
+    output(a) <- log(t)
+    output(b) <- log(t, 2)
+    output(c) <- log(t, 10)
+  })
+  tt <- seq(0.0001, 5, length.out = 101)
+  yy <- gen()$run(tt)
+  expect_equal(yy[, "a"], log(tt))
+  expect_equal(yy[, "b"], log2(tt))
+  expect_equal(yy[, "c"], log10(tt))
+})
+
+
+test_that("pow", {
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 0
+    output(a) <- min(t, t^2 - 2, -t)
+    output(b) <- max(t, t^2 - 2, -t)
+  })
+  tt <- seq(0.0001, 5, length.out = 101)
+  yy <- gen()$run(tt)
+  expect_equal(yy[, "a"], pmin(tt, tt^2 - 2, -tt))
+  expect_equal(yy[, "b"], pmax(tt, tt^2 - 2, -tt))
+})
+
+
+test_that("%%", {
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 0
+    s <- sin(1) # does not appear exactly
+    q <- 1.0    # appears exactly
+    output(s1) <-  t %%  s
+    output(s2) <- -t %%  s
+    output(s3) <-  t %% -s
+    output(s4) <- -t %% -s
+    output(q1) <-  t %%  q
+    output(q2) <- -t %%  q
+    output(q3) <-  t %% -q
+    output(q4) <- -t %% -q
+  })
+  tt <- seq(-5, 5, length.out = 101)
+  mod <- gen()
+  res <- mod$run(tt)
+  s <- mod$contents()[["s"]]
+  q <- mod$contents()[["q"]]
+
+  expect_equal(res[, "s1"],  tt %%  s)
+  expect_equal(res[, "s2"], -tt %%  s)
+  expect_equal(res[, "s3"],  tt %% -s)
+  expect_equal(res[, "s4"], -tt %% -s)
+
+  expect_equal(res[, "q1"],  tt %%  q)
+  expect_equal(res[, "q2"], -tt %%  q)
+  expect_equal(res[, "q3"],  tt %% -q)
+  expect_equal(res[, "q4"], -tt %% -q)
+})
+
+
+test_that("%/%", {
+  ## As for %% but with %/%
+  gen <- odin_js({
+    deriv(y) <- 0
+    initial(y) <- 0
+    s <- sin(1) # does not appear exactly
+    q <- 1.0    # appears exactly
+    output(s1) <-  t %/%  s
+    output(s2) <- -t %/%  s
+    output(s3) <-  t %/% -s
+    output(s4) <- -t %/% -s
+    output(q1) <-  t %/%  q
+    output(q2) <- -t %/%  q
+    output(q3) <-  t %/% -q
+    output(q4) <- -t %/% -q
+  })
+  tt <- seq(-5, 5, length.out = 101)
+  mod <- gen()
+  res <- mod$run(tt)
+  s <- mod$contents()[["s"]]
+  q <- mod$contents()[["q"]]
+
+  expect_equal(res[, "s1"],  tt %/%  s)
+  expect_equal(res[, "s2"], -tt %/%  s)
+  expect_equal(res[, "s3"],  tt %/% -s)
+  expect_equal(res[, "s4"], -tt %/% -s)
+
+  expect_equal(res[, "q1"],  tt %/%  q)
+  expect_equal(res[, "q2"], -tt %/%  q)
+  expect_equal(res[, "q3"],  tt %/% -q)
+  expect_equal(res[, "q4"], -tt %/% -q)
+})
+
+
+test_that("2-arg round", {
+  gen <- odin_js({
+    deriv(x) <- 1
+    initial(x) <- 1
+    output(y) <- TRUE
+    output(z) <- TRUE
+    n <- user(0)
+    y <- round(t, n)
+    z <- round(t)
+  })
+
+  mod0 <- gen(n = 0)
+  mod1 <- gen(n = 1)
+  mod2 <- gen(n = 2)
+
+  tt <- seq(0, 1, length.out = 101)
+  yy0 <- mod0$run(tt)
+  yy1 <- mod1$run(tt)
+  yy2 <- mod2$run(tt)
+
+  yy0[51, "z"] <- 0 # FIXME
+  yy1[51, "z"] <- 0 # FIXME
+  yy2[51, "z"] <- 0 # FIXME
+
+  expect_equal(yy0[, "z"], round(tt))
+  expect_equal(yy1[, "z"], round(tt))
+  expect_equal(yy2[, "z"], round(tt))
+
+  yy0[51, "y"] <- 0 # FIXME
+  yy1[c(6, 26, 46, 66, 86), "y"] <- c(0, 0.2, 0.4, 0.6, 0.8) # FIXME
+
+  expect_equal(yy0[, "y"], round(tt, 0))
+  expect_equal(yy1[, "y"], round(tt, 1))
+  expect_equal(yy2[, "y"], round(tt, 2))
+})

--- a/tests/testthat/test-run-library.R
+++ b/tests/testthat/test-run-library.R
@@ -128,16 +128,9 @@ test_that("2-arg round", {
   yy1 <- mod1$run(tt)
   yy2 <- mod2$run(tt)
 
-  yy0[51, "z"] <- 0 # FIXME
-  yy1[51, "z"] <- 0 # FIXME
-  yy2[51, "z"] <- 0 # FIXME
-
   expect_equal(yy0[, "z"], round(tt))
   expect_equal(yy1[, "z"], round(tt))
   expect_equal(yy2[, "z"], round(tt))
-
-  yy0[51, "y"] <- 0 # FIXME
-  yy1[c(6, 26, 46, 66, 86), "y"] <- c(0, 0.2, 0.4, 0.6, 0.8) # FIXME
 
   expect_equal(yy0[, "y"], round(tt, 0))
   expect_equal(yy1[, "y"], round(tt, 1))

--- a/tests/testthat/test-run-regression.R
+++ b/tests/testthat/test-run-regression.R
@@ -1,0 +1,42 @@
+context("run: regression")
+
+test_that("bug #78", {
+  gen <- odin_js({
+    n <- 2
+    m <- 2
+    deriv(S[, ]) <- 0
+    deriv(I) <- S[n,m]
+    dim(S) <- c(n,m)
+    initial(S[, ]) <- S0[i, j]
+    initial(I) <- 0
+    S0[, ] <- user()
+    dim(S0) <- c(n, m)
+  })
+
+  parameters <- list(S0 = cbind(c(1, 2), c(3, 4)))
+  mod <- gen(user = parameters)
+  expect_equal(mod$deriv(0, mod$initial(0)),
+               c(4, rep(0, 4)))
+})
+
+
+## 75
+test_that("bug #75", {
+  gen <- odin_js({
+    deriv(S) <- 1
+    deriv(I) <- 2
+    deriv(R) <- 3
+
+    initial(S) <- N - I - R
+    initial(I) <- I0
+    initial(R) <- 5
+
+    N <- 100
+    I0 <- 1
+  })
+
+  dat <- gen()$contents()
+  expect_equal(dat$initial_S, 94)
+  expect_equal(dat$initial_I, 1)
+  expect_equal(dat$initial_R, 5)
+})

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -60,8 +60,7 @@ test_that("array stochastic variables are time dependent", {
   tt <- 0:20
   model_set_seed(mod, 1)
   yy <- mod$run(tt)
-  ## zz <- mod$transform_variables(yy)
-  zz <- list(x = unname(yy[, 2:4]))
+  zz <- mod$transform_variables(yy)
   model_set_seed(mod, 1)
   cmp <- rbind(0,
                matrix(model_random_numbers(mod, "normal", 3 * 20), 20, 3, TRUE))

--- a/tests/testthat/test-run-stochastic.R
+++ b/tests/testthat/test-run-stochastic.R
@@ -140,7 +140,7 @@ test_that("round & rbinom", {
 
   mod <- gen(p = 1, size = 0.4)
   expect_equal(mod$initial(0), 0)
-  mod$set_user(list(p = 1, size = 1.7))
+  mod$set_user(p = 1, size = 1.7)
   expect_equal(mod$initial(0), 2)
 })
 

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -188,8 +188,9 @@ test_that("convert matrices to odin style matrices", {
 
 test_that("detect ragged data", {
   ctx <- odin_js_support()
-  expect_js_error(ctx$call("flattenArray", list(1:3, 1:2), "x"),
-                  "Inconsistent array")
+  expect_error(ctx$call("flattenArray", list(1:3, 1:2), "x"),
+               "Inconsistent array",
+               class = "std::runtime_error")
 
   ## Not very clever though - this is a bug if the user provides
   ## terrible input.

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -159,3 +159,41 @@ test_that("generate sum", {
   expect_equal(code,
                readLines(system.file("support_sum.js", package = "odin.js")))
 })
+
+
+test_that("convert matrices to odin style matrices", {
+  ctx <- odin_js_support()
+
+  v <- 1:6
+  expect_equal(
+    ctx$call("flattenArray", v, "v"),
+    list(data = 1:6, dim = 6))
+
+  m <- matrix(1:6, 2, 3)
+  expect_equal(
+    ctx$call("flattenArray", to_json_columnwise(m), "m"),
+    list(data = 1:6, dim = c(2, 3)))
+
+  a <- array(1:24, c(2, 3, 4))
+  expect_equal(
+    ctx$call("flattenArray", to_json_columnwise(a), "a"),
+    list(data = c(a), dim = dim(a)))
+
+  a4 <- array(1:120, c(2, 3, 4, 5))
+  expect_equal(
+    ctx$call("flattenArray", to_json_columnwise(a4), "a4"),
+    list(data = c(a4), dim = dim(a4)))
+})
+
+
+test_that("detect ragged data", {
+  ctx <- odin_js_support()
+  expect_js_error(ctx$call("flattenArray", list(1:3, 1:2), "x"),
+                  "Inconsistent array")
+
+  ## Not very clever though - this is a bug if the user provides
+  ## terrible input.
+  expect_equal(
+    ctx$call("flattenArray", list(1:3, 1:2, 1:4), "x"),
+    list(data = c(1:3, 1:2, 1:4), dim = c(3, 3)))
+})


### PR DESCRIPTION
This PR fixes a number of interface problems and refactors away some problems from the previous PR, mostly in advance of either reuniting with odin, or just keeping the experience similar.

* Unused parameters are warned about (or errors thrown) which helps a lot with spelling mistakes
* More functions are supported - notably `^`, `%%`, `%/%`, and 2-arg round - these functions all follow R semantics including rounding 0.5 to even
* Unsupported functions throw an error during code generation, not at runtime
* Matrices are supported as user parameters directly (not just with the data/dim object)
* The R wrapper (used for testing) becomes more similar to the main odin class, simplifying testing:
  * `$contents()` shapes arrays on return
  * `$transform_variables()` is implemented
  * a readonly `$ir` field is present, which enables `coef()` to work
  * The custom error class is stripped from V8 errors so that testthat no longer warns about it
* A bunch more tests were copied over - now everything except for the delay tests