### PR TITLE
mrc-1540: Allow tuning the ode solver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.7
+Version: 0.1.8
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -138,8 +138,9 @@ generate_js_core_run <- function(eqs, dat, rewrite) {
     body <- sprintf("return iterateOdin(this, times, y0, %s);",
                     rewrite(dat$data$output$length))
   } else {
-    args <- c("times", "y0", "tcrit", "atol", "rtol")
-    body <- "return integrateOdin(this, times, y0, tcrit, atol, rtol);"
+    args <- c("times", "y0", "tcrit", "atol", "rtol", "maxSteps")
+    body <-
+      "return integrateOdin(this, times, y0, tcrit, atol, rtol, maxSteps);"
   }
   js_function(args, body)
 }

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -138,8 +138,8 @@ generate_js_core_run <- function(eqs, dat, rewrite) {
     body <- sprintf("return iterateOdin(this, times, y0, %s);",
                     rewrite(dat$data$output$length))
   } else {
-    args <- c("times", "y0", "tcrit")
-    body <- "return integrateOdin(this, times, y0, tcrit);"
+    args <- c("times", "y0", "tcrit", "atol", "rtol")
+    body <- "return integrateOdin(this, times, y0, tcrit, atol, rtol);"
   }
   js_function(args, body)
 }

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -144,7 +144,8 @@ R6_odin_js_wrapper <- R6::R6Class(
       ret
     },
 
-    run = function(t, y = NULL, ..., tcrit = NULL, use_names = TRUE) {
+    run = function(t, y = NULL, ..., atol = NULL, rtol = NULL,
+                   tcrit = NULL, use_names = TRUE) {
       t_js <- to_json(t, auto_unbox = FALSE)
       if (is.null(y)) {
         y_js <- V8::JS("null")
@@ -154,11 +155,17 @@ R6_odin_js_wrapper <- R6::R6Class(
       if (is.null(tcrit)) {
         tcrit <- V8::JS("null")
       }
+      if (is.null(atol)) {
+        atol <- V8::JS("null")
+      }
+      if (is.null(rtol)) {
+        rtol <- V8::JS("null")
+      }
 
       ## NOTE: tcrit here is ignored when calling the discrete time
       ## model
       res <- private$js_call(sprintf("%s.run", private$name),
-                             t_js, y_js, tcrit)
+                             t_js, y_js, tcrit, atol, rtol)
       if (use_names) {
         colnames(res$y) <- res$names
       }

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -144,8 +144,8 @@ R6_odin_js_wrapper <- R6::R6Class(
       ret
     },
 
-    run = function(t, y = NULL, ..., atol = NULL, rtol = NULL,
-                   tcrit = NULL, use_names = TRUE) {
+    run = function(t, y = NULL, ..., tcrit = NULL, atol = NULL, rtol = NULL,
+                   step_max_n = NULL, use_names = TRUE) {
       t_js <- to_json(t, auto_unbox = FALSE)
       if (is.null(y)) {
         y_js <- V8::JS("null")
@@ -161,11 +161,14 @@ R6_odin_js_wrapper <- R6::R6Class(
       if (is.null(rtol)) {
         rtol <- V8::JS("null")
       }
+      if (is.null(step_max_n)) {
+        step_max_n <- V8::JS("null")
+      }
 
       ## NOTE: tcrit here is ignored when calling the discrete time
       ## model
       res <- private$js_call(sprintf("%s.run", private$name),
-                             t_js, y_js, tcrit, atol, rtol)
+                             t_js, y_js, tcrit, atol, rtol, step_max_n)
       if (use_names) {
         colnames(res$y) <- res$names
       }

--- a/inst/support.js
+++ b/inst/support.js
@@ -27,7 +27,7 @@ function integrateOdin(obj, times, y0, tcrit, atol, rtol) {
     if (!isMissing(atol)) {
         ctl.atol = atol;
     }
-    if (isMissing(rtol)) {
+    if (!isMissing(rtol)) {
         ctl.rtol = rtol;
     }
     var sol = null;

--- a/inst/support.js
+++ b/inst/support.js
@@ -8,7 +8,7 @@ function zeros(n) {
 }
 
 
-function integrateOdin(obj, times, y0, tcrit) {
+function integrateOdin(obj, times, y0, tcrit, atol, rtol) {
     var t0 = times[0];
     var t1 = times[times.length - 1];
     if (obj.metadata.interpolateTimes !== null) {
@@ -23,6 +23,12 @@ function integrateOdin(obj, times, y0, tcrit) {
     var ctl = {};
     if (tcrit !== null) {
         ctl.tcrit = tcrit;
+    }
+    if (!isMissing(atol)) {
+        ctl.atol = atol;
+    }
+    if (isMissing(rtol)) {
+        ctl.rtol = rtol;
     }
     var sol = null;
     if (typeof obj.output === "function") {

--- a/inst/support.js
+++ b/inst/support.js
@@ -8,7 +8,7 @@ function zeros(n) {
 }
 
 
-function integrateOdin(obj, times, y0, tcrit, atol, rtol) {
+function integrateOdin(obj, times, y0, tcrit, atol, rtol, maxSteps) {
     var t0 = times[0];
     var t1 = times[times.length - 1];
     if (obj.metadata.interpolateTimes !== null) {
@@ -29,6 +29,9 @@ function integrateOdin(obj, times, y0, tcrit, atol, rtol) {
     }
     if (!isMissing(rtol)) {
         ctl.rtol = rtol;
+    }
+    if (!isMissing(maxSteps)) {
+        ctl.maxSteps = maxSteps;
     }
     var sol = null;
     if (typeof obj.output === "function") {

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -161,3 +161,16 @@ test_that("can adjust tolerance in the solver", {
   y2 <- mod$run(tt, atol = 1e-10, rtol = 1e-10)
   expect_true(mean(abs(y1[, 2] - sin(tt))) > 10 * mean(abs(y2[, 2] - sin(tt))))
 })
+
+
+test_that("can adjust max steps", {
+  gen <- odin_js({
+    deriv(y) <- cos(t)
+    initial(y) <- 0
+  })
+  mod <- gen()
+  tt <- seq(0, 2 * pi, length.out = 101)
+  expect_error(
+    mod$run(tt, step_max_n = 10),
+    "Integration failure: too many steps")
+})

--- a/tests/testthat/test-odin-js.R
+++ b/tests/testthat/test-odin-js.R
@@ -148,3 +148,16 @@ test_that("some R functions are not available", {
     }),
     "unsupported function 'choose'")
 })
+
+
+test_that("can adjust tolerance in the solver", {
+  gen <- odin_js({
+    deriv(y) <- cos(t)
+    initial(y) <- 0
+  })
+  mod <- gen()
+  tt <- seq(0, 2 * pi, length.out = 101)
+  y1 <- mod$run(tt, atol = 1e-3, rtol = 1e-3)
+  y2 <- mod$run(tt, atol = 1e-10, rtol = 1e-10)
+  expect_true(mean(abs(y1[, 2] - sin(tt))) > 10 * mean(abs(y2[, 2] - sin(tt))))
+})


### PR DESCRIPTION
This PR passes the `atol`, `rtol` and `maxSteps` control parameter through to the  solver.  Defaults are 1e-6, 1e-6 and 10000 (see [dopri.js](https://github.com/mrc-ide/dopri-js/blob/83b6ae6858ae46f99372aa7f97e10ee4fa62c183/src/control.ts#L10-L11)) which is broadly similar to the R dde package (looks like the R package allows 100k steps by default)