### PR TITLE
Support as.integer function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.8
+Version: 0.1.9
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/R/generate_js_sexp.R
+++ b/R/generate_js_sexp.R
@@ -95,7 +95,9 @@ FUNCTIONS_RENAME <- c(
   ceiling = "Math.ceil",
   round = "round2",
   "%%" = "modr",
-  "%/%" = "intdivr")
+  "%/%" = "intdivr",
+  "as.integer" = "Math.floor"
+)
 
 
 FUNCTIONS_MATH <- c(

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1254,3 +1254,33 @@ test_that("user parameter validation", {
     mod$set_user(user = list(x = 1), unused_user_action = "error"),
     "Unknown user parameters: x")
 })
+
+test_that("force integer on use", {
+  gen <- odin({
+    vec[] <- i
+    dim(vec) <- 2
+    idx <- if (t > 5) 2 else 1
+    deriv(x) <- vec[as.integer(idx)]
+    initial(x) <- 0
+  })
+
+  mod <- gen()
+  t <- seq(0, 10, length.out = 101)
+  y <- mod$run(t, atol = 1e-9, rtol = 1e-9)
+  expect_equal(y[, 2], ifelse(t <= 5, t, 2 * t - 5))
+})
+
+
+test_that("force integer on a numeric vector truncates", {
+  gen <- odin({
+    vec[] <- i
+    dim(vec) <- 10
+    idx <- user()
+    initial(x) <- vec[as.integer(idx)]
+    deriv(x) <- 0
+  })
+
+  expect_equal(gen(idx = 1.5)$initial(), 1)
+  expect_equal(gen(idx = 3 - 1e-8)$initial(), 2)
+  expect_equal(gen(idx = 3 + 1e-8)$initial(), 3)
+})


### PR DESCRIPTION
Odin users are [encouraged to use](https://mrc-ide.github.io/odin/articles/functions.html#array-support)`as.integer` to index odin variables.

This adds support for as.integer to odin.js.

as.integer is probably not necessary in the js version, but I've added it for consistency.

Things to look out for:

 * Are the tests in the right file?