### PR TITLE
Expose more control parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.js
 Title: 'odin' 'JavaScript' support
-Version: 0.1.10
+Version: 0.1.11
 Authors@R:
     person(given = "Rich",
            family = "FitzJohn",

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ coverage:
 
 js: inst/dopri.js
 
-js/dopri.js: js/package.json js/in.js
+js/dopri.js: js/package.json js/dopri.in.js
 	./js/build
 
 inst/support.min.js: inst/support.js

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -138,9 +138,9 @@ generate_js_core_run <- function(eqs, dat, rewrite) {
     body <- sprintf("return iterateOdin(this, times, y0, %s);",
                     rewrite(dat$data$output$length))
   } else {
-    args <- c("times", "y0", "tcrit", "atol", "rtol", "maxSteps")
+    args <- c("times", "y0", "control")
     body <-
-      "return integrateOdin(this, times, y0, tcrit, atol, rtol, maxSteps);"
+      "return integrateOdin(this, times, y0, control);"
   }
   js_function(args, body)
 }

--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -149,31 +149,29 @@ R6_odin_js_wrapper <- R6::R6Class(
     },
 
     run = function(t, y = NULL, ..., tcrit = NULL, atol = NULL, rtol = NULL,
-                   step_max_n = NULL, use_names = TRUE,
-                   return_statistics = FALSE) {
+                   step_max_n = NULL, step_size_min = NULL,
+                   step_size_max = NULL, step_size_min_allow = NULL,
+                   use_names = TRUE, return_statistics = FALSE) {
       t_js <- to_json(t, auto_unbox = FALSE)
       if (is.null(y)) {
         y_js <- V8::JS("null")
       } else {
         y_js <- to_json(y, auto_unbox = FALSE)
       }
-      if (is.null(tcrit)) {
-        tcrit <- V8::JS("null")
-      }
-      if (is.null(atol)) {
-        atol <- V8::JS("null")
-      }
-      if (is.null(rtol)) {
-        rtol <- V8::JS("null")
-      }
-      if (is.null(step_max_n)) {
-        step_max_n <- V8::JS("null")
-      }
+      control <- list(atol = atol,
+                      rtol = rtol,
+                      tcrit = tcrit,
+                      maxSteps = step_max_n,
+                      stepSizeMin = step_size_min,
+                      stepSizeMax = step_size_max,
+                      stepSizeMinAllow = step_size_min_allow)
+      control <- control[!vlapply(control, is.null)]
+      control_js <- to_json(control, auto_unbox = TRUE)
 
       ## NOTE: tcrit here is ignored when calling the discrete time
       ## model
       res <- private$js_call(sprintf("%s.run", private$name),
-                             t_js, y_js, tcrit, atol, rtol, step_max_n)
+                             t_js, y_js, control_js)
       if (use_names) {
         colnames(res$y) <- res$names
       }

--- a/inst/random.js
+++ b/inst/random.js
@@ -2261,7 +2261,7 @@ if ((typeof module) == 'object' && module.exports) {
 );
 
 },{"crypto":33}],32:[function(require,module,exports){
-(function (global){
+(function (global){(function (){
 global.seedrandom = require("seedrandom");
 global.random = require("random");
 global.random.use(seedrandom("odin.js"));
@@ -2287,7 +2287,7 @@ global.random.rbinom = function(n, p) {
     return ret;
 }
 
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+}).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"random":23,"seedrandom":24}],33:[function(require,module,exports){
 
 },{}]},{},[32]);

--- a/inst/support.js
+++ b/inst/support.js
@@ -12,7 +12,8 @@ function integrateOdin(obj, times, y0, control) {
     var t0 = times[0];
     var t1 = times[times.length - 1];
     if (obj.metadata.interpolateTimes !== null) {
-        tcrit = interpolateCheckT(times, obj.metadata.interpolateTimes, tcrit);
+        control.tcrit = interpolateCheckT(times, obj.metadata.interpolateTimes,
+                                          control.tcrit);
     }
     if (isMissing(y0)) {
       y0 = obj.initial(times[0]);

--- a/inst/support.js
+++ b/inst/support.js
@@ -8,7 +8,7 @@ function zeros(n) {
 }
 
 
-function integrateOdin(obj, times, y0, tcrit, atol, rtol, maxSteps) {
+function integrateOdin(obj, times, y0, control) {
     var t0 = times[0];
     var t1 = times[times.length - 1];
     if (obj.metadata.interpolateTimes !== null) {
@@ -20,27 +20,14 @@ function integrateOdin(obj, times, y0, tcrit, atol, rtol, maxSteps) {
     var rhs = function(t, y, dy) {
         obj.rhs(t, y, dy);
     };
-    var ctl = {};
-    if (tcrit !== null) {
-        ctl.tcrit = tcrit;
-    }
-    if (!isMissing(atol)) {
-        ctl.atol = atol;
-    }
-    if (!isMissing(rtol)) {
-        ctl.rtol = rtol;
-    }
-    if (!isMissing(maxSteps)) {
-        ctl.maxSteps = maxSteps;
-    }
     var solver;
     if (typeof obj.output === "function") {
         var output = function(t, y) {
             return obj.output(t, y);
         }
-        solver = new dopri.Dopri(rhs, y0.length, ctl, output);
+        solver = new dopri.Dopri(rhs, y0.length, control, output);
     } else {
-        solver = new dopri.Dopri(rhs, y0.length, ctl);
+        solver = new dopri.Dopri(rhs, y0.length, control);
     }
     solver.initialise(t0, y0);
     var sol = solver.run(t1);

--- a/inst/test.js
+++ b/inst/test.js
@@ -1,5 +1,5 @@
 // code for use with a test model:
-function run(name, user, t, y) {
+function run(name, user, t, y, control) {
     var mod = new odin[name](user);
-    return mod.run(t, y);
+    return mod.run(t, y, control);
 }

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,9 +19,9 @@
             "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
         },
         "dopri": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.7.tgz",
-            "integrity": "sha512-17vUmybOB3aFFMXD9/cjU7z9z2MH6eLkVj0UVewu6RmhhuYOUId2n4uowRTKHRwmQNNqxQsXtFyGMa9py8a5iA=="
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.8.tgz",
+            "integrity": "sha512-KN5IOC8+Y3JLjhbxqy20rkBOnowHoEePz2DTDZ14ojYqw/uy6jyTgTykd1ZhCMzTYGo07Z4jskpqwAwq/gBNpw=="
         },
         "ow": {
             "version": "0.4.0",

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/mrc-ide/odin.js/issues"
     },
     "dependencies": {
-        "dopri": "^0.0.7",
+        "dopri": "^0.0.8",
         "random": "^2.2.0"
     },
     "homepage": "https://github.com/mrc-ide/odin.js#readme"

--- a/tests/testthat/helper-odin-js.R
+++ b/tests/testthat/helper-odin-js.R
@@ -5,13 +5,18 @@ sort_list <- function(x) {
 }
 
 
-call_odin_bundle <- function(context, name, user, t, y = NULL) {
+call_odin_bundle <- function(context, name, user, t, y = NULL, control = NULL) {
   context$eval(package_js("test.js"))
   user <- to_json_user(user)
   if (is.null(y)) {
     y <- js_null()
   }
-  res <- context$call("run", "odin", user, t, y)
+  if (is.null(control)) {
+    control_js <- to_json(setNames(list(), character(0)))
+  } else {
+    control_js <- to_json(control, auto_unbox = TRUE)
+  }
+  res <- context$call("run", "odin", user, t, y, control_js)
   colnames(res$y) <- res$names
   res$y
 }


### PR DESCRIPTION
This Pr updates dopri.js to 0.0.8 and exposes the complete control interface. Because this made the current approach of passing args like atol, rtol directly unsustainable, I've put these all into a control dict.

The new control parameters include `stepSizeMin`, `stepSizeMinAllow`, `stepSizeMax` in addition to `atol` and `rtol`, with interpretations the same as the `snake_case` options in dde.